### PR TITLE
Migrating from Bootstrap 3 to Bootstrap 5 

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -11,7 +11,10 @@
         "build": {
           "builder": "@angular-devkit/build-angular:browser",
           "options": {
-            "allowedCommonJsDependencies": ["os", "stream"],
+            "allowedCommonJsDependencies": [
+              "os",
+              "stream"
+            ],
             "outputPath": "dist",
             "index": "src/index.html",
             "main": "src/main.ts",
@@ -59,7 +62,6 @@
             "prod": {
               "optimization": false,
               "sourceMap": false,
-              "extractCss": false,
               "namedChunks": false,
               "aot": false,
               "extractLicenses": true,

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   },
   "private": true,
   "dependencies": {
-    "@angular-builders/custom-webpack": "^16.0.0",
     "@angular/animations": "~15.2.9",
     "@angular/cdk": "~15.2.9",
     "@angular/common": "~15.2.9",

--- a/src/app/admin/admin-reports/login-reports.component.css
+++ b/src/app/admin/admin-reports/login-reports.component.css
@@ -2,6 +2,5 @@
 
 .right-chart-control {
     float: right;
-    margin-top: 20px
   }
 

--- a/src/app/admin/admin-reports/login-reports.component.html
+++ b/src/app/admin/admin-reports/login-reports.component.html
@@ -1,14 +1,18 @@
 <!--suppress TypeScriptUnresolvedVariable -->
-<div class="report-section">
+<div class="report-section pb-5">
 
   <div class="row">
     <div class="col-xs-8 col-sm-6">
       <h1 class="srt-blue analytic-big-title" id="anchor-Logins-Last-30-Days">Logins</h1>
     </div>
     <div class="col-xs-4 col-sm-6">
-      <div class="right-chart-control">
-        <button label="Download CSV" class="p-button srt-button" style="float:none; display:inline; width:125px;" (click)="downloadLoginData(data)"  >Download CSV</button>
-        <p-dropdown [options]="timeSelection" (onChange)="timeChange($event)" [(ngModel)]="selection"></p-dropdown>
+      <div class="row right-chart-control">
+        <div class="col-6">
+          <button label="Download CSV" type="button" class="btn p-button srt-button" style="display: inline-flex;" (click)="downloadLoginData(data)">Download CSV</button>
+        </div>
+        <div class="col-6">
+          <p-dropdown [options]="timeSelection" (onChange)="timeChange($event)" [(ngModel)]="selection"></p-dropdown>
+        </div>
       </div>
     </div>
   </div>
@@ -18,7 +22,7 @@
   <span class="visually-hidden" [innerHTML]="readerSupplement"></span>
 
 
-  <h1 class="srt-blue analytic-big-title" id="anchor-User-Login-Report">User Login Report</h1>
+  <h1 class="srt-blue analytic-big-title pt-3" id="anchor-User-Login-Report">User Login Report</h1>
   <p-table [value]="userData" [columns]="userChartCols" styleClass="pDataTable p-datatable-gridlines">
     <ng-template pTemplate="header" let-columns>
       <tr>

--- a/src/app/admin/admin.component.html
+++ b/src/app/admin/admin.component.html
@@ -12,7 +12,7 @@
   <!-- reports -->
   <div *ngIf="this.activeTab == 'reports'" style="clear:both;" class="row nopadding">
     <div class="sticky-nav col-md-2 hidden-xs hidden-sm" style="padding-top:80px;">
-      <ul class="usa-sidenav-list" style="">
+      <ul class="usa-sidenav-list sticky-top">
         <li (click)="scroll('anchor-Logins-Last-30-Days');">Logins</li>
         <li (click)="scroll('anchor-User-Login-Report');">User Login Report</li>
         <li (click)="scroll('anchor-Feedback-Table');">Feedback Table</li>

--- a/src/app/admin/metric-downloads/metric-downloads.component.html
+++ b/src/app/admin/metric-downloads/metric-downloads.component.html
@@ -1,12 +1,5 @@
 <main id="content" class="bypass-block-target">
-
-
-    <div class="sticky-nav col-md-2 hidden-xs hidden-sm" style="padding-top:80px;">
-      <ul class="usa-sidenav-list" style="">
-        <li (click)="scroll('anchor-scanned-sol-by-date-metrics');">Solicitation Metrics</li>
-      </ul>
-    </div>
-
+    
     <div class="col-md-10 no-padding">
       <div class="report-section">
         <h1 class="srt-blue analytic-big-title" id="anchor-scanned-sol-by-date-metrics">Scanned Solicitation by Date Metrics</h1>

--- a/src/app/analytics/analytics.component.html
+++ b/src/app/analytics/analytics.component.html
@@ -57,24 +57,26 @@
 
         <div class="col-md-12 no-padding clearfix analytic-section1-container" tabindex="0" role="region" aria-labelledby="region3">
             <div class="row-eq-height">
-                <div class="col-md-6 no-padding">
-                    <div class="col-md-6 no-padding">
-                      <app-donut-chart
-                        [doughnutChartDataInput]="ComplianceRateChart"
-                        [title]="'Preliminary Compliance Rate'"
-                        [componentTooltip]="'Compliance Rate = (Total compliant ICT solicitations / Total ICT solicitations scanned) * 100%'">
-                      </app-donut-chart>
-                    </div>
-                    <div class="col-md-6 no-padding">
-                      <app-donut-chart
-                          [doughnutChartDataInput]="ConversionRateChart"
-                          [title]="'Conversion Rate'"
-                          [componentTooltip]="'Conversion Rate = (# updated compliant solicitations / Total non-compliant ICT solicitations) * 100%'">
-                      </app-donut-chart>
+                <div class="col-md-12 col-lg-8 col-sm-12 no-padding">
+                    <div class="row">
+                        <div class="col-md-6 no-padding">
+                        <app-donut-chart
+                            [doughnutChartDataInput]="ComplianceRateChart"
+                            [title]="'Preliminary Compliance Rate'"
+                            [componentTooltip]="'Compliance Rate = (Total compliant ICT solicitations / Total ICT solicitations scanned) * 100%'">
+                        </app-donut-chart>
+                        </div>
+                        <div class="col-md-6 no-padding">
+                        <app-donut-chart
+                            [doughnutChartDataInput]="ConversionRateChart"
+                            [title]="'Conversion Rate'"
+                            [componentTooltip]="'Conversion Rate = (# updated compliant solicitations / Total non-compliant ICT solicitations) * 100%'">
+                        </app-donut-chart>
+                        </div>
                     </div>
                 </div>
 
-                <div class="col-md-6 no-padding">
+                <div class="col-lg-4 col-md-12 col-sm-12 no-padding">
                     <app-top-srt-actions [TopSRTActionChart]="TopSRTActionChart"></app-top-srt-actions>
                 </div>
             </div>

--- a/src/app/analytics/scanned-solicitation/scanned-solicitation.component.html
+++ b/src/app/analytics/scanned-solicitation/scanned-solicitation.component.html
@@ -5,7 +5,7 @@
          tooltipPosition="bottom">
         <i tabindex="0" alt="hi there" class="fa fa-info-circle info" aria-hidden="true" ></i>
     </sup>
-  <a (click)="downloadCSV()" style="padding-left: 10px; font-size: 12px;" class="link-secondary link-offset-2 link-underline-opacity-25 link-underline-opacity-100-hover">Download CSV</a>
+  <a (click)="downloadCSV()" style="padding-left: 10px; font-size: 12px; cursor: pointer;" class="link-secondary link-offset-2 link-underline-opacity-25 link-underline-opacity-100-hover">Download CSV</a>
 </h2>
 
 <div class="barchart">

--- a/src/app/analytics/scanned-solicitation/scanned-solicitation.component.html
+++ b/src/app/analytics/scanned-solicitation/scanned-solicitation.component.html
@@ -5,7 +5,7 @@
          tooltipPosition="bottom">
         <i tabindex="0" alt="hi there" class="fa fa-info-circle info" aria-hidden="true" ></i>
     </sup>
-  <span (click)="downloadCSV()" style="padding-left: 10px; font-weight: normal; font-size: 12px;">Download CSV</span>
+  <a (click)="downloadCSV()" style="padding-left: 10px; font-size: 12px;" class="link-secondary link-offset-2 link-underline-opacity-25 link-underline-opacity-100-hover">Download CSV</a>
 </h2>
 
 <div class="barchart">

--- a/src/app/app.component.css
+++ b/src/app/app.component.css
@@ -4,18 +4,6 @@
     padding: 0px !important;
 }
 
-.gov-msg:after {
-    /* symbol for "opening" panels */
-    font-family: 'Glyphicons Halflings';  /* essential for enabling glyphicon */
-    content: "\e114";    /* adjust as needed, taken from bootstrap.css */
-    float: right;        /* adjust as needed */
-    color: inherit;         /* adjust as needed */
-    font-size: 10px;
-}
-.gov-msg.collapsed:after {
-    /* symbol for "collapsed" panels */
-    content: "\e113";    /* adjust as needed, taken from bootstrap.css */
-}
 
 * {
     font-family: Source Sans Pro !important
@@ -48,5 +36,5 @@ display: table
 .gsa-scontent{
     display: table-cell;
     vertical-align: top;
-    font-size: 1.6rem;
+    font-size: 1.2rem;
 }

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -9,7 +9,7 @@
                     An official website of the United States government
                 </div>
                 <div class="gsa-subtitle" style="cursor: pointer">
-                    <a href="" onclick="return false;" data-toggle="collapse" data-target="#msg" class="gov-msg collapsed" style="color:#0000C7">Here's how you know&nbsp;&nbsp;</a>
+                    <a href="" onclick="return false;" data-bs-toggle="collapse" data-bs-target="#msg" class="gov-msg collapsed" style="color:#0000C7">Here's how you know&nbsp;&nbsp;</a>
                 </div>
             </div>
             <div style="float: right;" class="version">

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -8,8 +8,8 @@
                 <div class="gsa-subtitle">
                     An official website of the United States government
                 </div>
-                <div class="gsa-subtitle" style="cursor: pointer">
-                    <a href="" onclick="return false;" data-bs-toggle="collapse" data-bs-target="#msg" class="gov-msg collapsed" style="color:#0000C7">Here's how you know&nbsp;&nbsp;</a>
+                <div class="gsa-subtitle dropdown-toggle" style="cursor: pointer">
+                    <a href="" onclick="return false;" data-bs-toggle="collapse" data-bs-target="#msg" class="gov-msg collapsed" style="color:#0000C7">Here's how you know<span class="caret"></span></a>
                 </div>
             </div>
             <div style="float: right;" class="version">
@@ -18,26 +18,28 @@
               <span style="display:none">Server Build date: {{buildDate}}</span>
               <span style="display:none">Server Environment: {{environment}}</span>
             </div>
-            <div id="msg" class="collapse clearfix" style="max-width: 1040px; clear: both">
-                <div class="col-sm-6 nopadding">
-                    <div class="clearfix gsa-sintr">
-                        <div class="gsa-sicon">
-                            <img class="usa-banner-icon usa-media_block-img" width="38px" height="38px"  src="../assets/icon-dot-gov.svg" alt="Dot gov">
+            <div id="msg" class="collapse clearfix container" style="clear: both;">
+                <div class="row">
+                    <div class="col-sm-6 nopadding">
+                        <div class="clearfix gsa-sintr">
+                            <div class="gsa-sicon">
+                                <img class="usa-banner-icon usa-media_block-img" width="38px" height="38px"  src="../assets/icon-dot-gov.svg" alt="Dot gov">
+                            </div>
+                            <div class="gsa-scontent">
+                            <strong>The .gov means it’s official.</strong>
+                                <br>
+                                Federal government websites always use a .gov or .mil domain. Before sharing sensitive information online, make sure you’re on a .gov or .mil site by inspecting your browser’s address (or “location”) bar.
+                            </div>
                         </div>
-                        <div class="gsa-scontent">
-                          <strong>The .gov means it’s official.</strong>
-                              <br>
-                              Federal government websites always use a .gov or .mil domain. Before sharing sensitive information online, make sure you’re on a .gov or .mil site by inspecting your browser’s address (or “location”) bar.
-                         </div>
                     </div>
-                </div>
-                <div class="col-sm-6 nopadding">
-                    <div class="clearfix gsa-sintr">
-                        <div class="gsa-sicon">
-                           <img class="usa-banner-icon usa-media_block-img" width="38px" height="38px" src="../assets/icon-https.svg" alt="SSL">
-                        </div>
-                        <div class="gsa-scontent">
-                          <p>This site is also protected by an SSL (Secure Sockets Layer) certificate that’s been signed by the U.S. government. The <strong>https://</strong> means all transmitted data is encrypted &nbsp;— in other words, any information or browsing history that you provide is transmitted securely.</p>
+                    <div class="col-sm-6 nopadding">
+                        <div class="clearfix gsa-sintr">
+                            <div class="gsa-sicon">
+                            <img class="usa-banner-icon usa-media_block-img" width="38px" height="38px" src="../assets/icon-https.svg" alt="SSL">
+                            </div>
+                            <div class="gsa-scontent">
+                            <p>This site is also protected by an SSL (Secure Sockets Layer) certificate that’s been signed by the U.S. government. The <strong>https://</strong> means all transmitted data is encrypted &nbsp;— in other words, any information or browsing history that you provide is transmitted securely.</p>
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -42,21 +42,27 @@ export class AppComponent implements OnInit {
   ) {
     globals.app = this;
     authService.checkToken().subscribe(
-      data => {
+      {
+        next: (data) => {
         this.authGuard.isLogin = data.isLogin;
         this.authGuard.isGSAAdmin = data.isGSAAdmin;
         this.isLogin = this.authGuard.isLogin;
         this.isGSAAdmin = this.authGuard.isGSAAdmin;
         this.firstName = localStorage.getItem('firstName');
         this.lastName = localStorage.getItem('lastName');
+        
+        //console.log('data:', data);
+        //console.log('this:', this);
+
 
         // debugger
         if (!this.authGuard.isLogin) {
           // don't clear cache here when using MAX CAS prototype
           // localStorage.clear();
         }
-      },
-      (error) => { console.log(error); }
+        },
+        error: (err: any) => { console.log(err); }
+      }
     );
   }
 

--- a/src/app/auth/auth.component.html
+++ b/src/app/auth/auth.component.html
@@ -9,7 +9,7 @@
             position: relative" >
     <div class="row spacing nopadding">
         <div class="row-eq-height" style="padding: 60px 0px">
-            <div class="col-lg-6 col-lg-offset-3 col-md-8 col-md-offset-2 col-sm-12" >
+            <div class="col-lg-6 offset-lg-3 col-md-8 offset-md-3 col-sm-12" >
                 <div style="padding: 40px;" class="srt-blue">
                     <h1 style="font-weight: 700;" class="srt-black">Solicitation Review Tool </h1>
                     <h3><b>Please note:</b>  We are performing maintenance and upgrades on system components. We apologize for the inconvenience.</h3>

--- a/src/app/auth/userlogin/userlogin.component.css
+++ b/src/app/auth/userlogin/userlogin.component.css
@@ -5,7 +5,6 @@
 }
 
 .form-group label {
-    /* font-weight.*300 */;
     font-size: 16px;
     width: 100%;
 }

--- a/src/app/header/header.component.css
+++ b/src/app/header/header.component.css
@@ -1,3 +1,5 @@
+
+/*
 #gsaDropdown ul.dropdown-menu{
 		padding: 5px 0px;
 		background-color: #112e51 !important;
@@ -5,29 +7,14 @@
 
 #gsaDropdown ul.dropdown-menu > li > a{
 		color: white;
-		/* font-weight.*300 */;
+		/* font-weight.*300 
 }
-
 
 #gsaDropdown ul.dropdown-menu > li > a:hover{
 		background-color: transparent!important;
 }
-.dropdown-item {
-	background-color: #112e51;
-	color: white;
-    border: none;
-    padding: 15px 0px;
-    text-align: left;
-    text-decoration: none;
-    display: inline-block;
-    font-size: 16px;
-		width: calc(100%);
-    margin-left: 0px;
-    padding-left: 15px;
-}
-.dropdown-toggle:focus {
-  outline: auto !important;
-}
+*/
+
 
 #srtlogo {
 	max-height: 40px;
@@ -107,15 +94,7 @@ hr {
 #navbar a {
 	padding-top: 20px;
 }
-#navbar a:link
-{
-    text-decoration: none;
-    color: #4c2c92;
-    font-family: Arial, sans-serif;
-    font-size: medium;
-    font-weight: bold;
-    letter-spacing: 1px;
-}
+
 /*#navbar a:active
 {
     text-decoration: none;
@@ -149,4 +128,11 @@ hr {
 .dropdown-menu {
     left: auto;
     right: -1px;
+}
+
+#menu-logout {
+  padding: 10px 20px; 
+  font-weight:400; 
+  font-size:medium; 
+  font-family: Arial, sans-serif;
 }

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -39,7 +39,7 @@
                             [routerLink]="['/admin']">Administration</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" target="_blank" href='https://app.buyaccessible.gov/'>
+                        <a class="nav-link" target="_blank" rel="noopener noreferrer" href='https://app.buyaccessible.gov/'>
                             Additional Resources
                         </a>
                     </li>

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -1,66 +1,76 @@
 <!-- SRTDashHeaderView -->
 
 <div id="header">
-        <a
-        id="skipMain" href="javascript:
+    <a id="skipMain" href="javascript:
         const oh=location.hash;
         location.hash='#content';
         location.hash=oh;
-        void(0);" class="visible-when-focused bypass-block-link"
-        style="color:black;">
-            Skip to Main content
-          </a>
-  <nav class="us-navbar navbar-default">
+        void(0);" class="visible-when-focused bypass-block-link" style="color:black;">
+        Skip to Main content
+    </a>
+    <nav class="us-navbar navbar navbar-expand-lg">
 
         <div class="container-fluid">
-            <div class="navbar-header nopadding" style="height: 60px" >
-                <a tabindex="-1" class="navbar-left" [routerLink]="['/home']" aria-label="SRT Home Page"><img id="srtlogo" alt='SRT Logo' src="../../assets/srtlogo.png"></a>
-            </div>
+            <a tabindex="-1" class="nopadding navbar-brand navbar-left" [routerLink]="['/home']"
+                aria-label="SRT Home Page"><img id="srtlogo" alt='SRT Logo' src="../../assets/srtlogo.png"></a>
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbar"
+                aria-controls="navbar" aria-expanded="false" aria-label="Toggle navigation">
+                <span class="navbar-toggler-icon"></span>
+            </button>
 
-        <div class="collapse navbar-collapse" id="navbar" role="navigation" aria-label="main navigation" >
+            <div class="collapse navbar-collapse" id="navbar" role="navigation" aria-label="main navigation" style="justify-content: end;">
 
-                <ul *ngIf="isLogin" class="nav navbar-nav" >
-                     <li data-toggle="tab" [ngClass]="{'active': GetHash('home')}" id="1" (click)="menuClick('/home');"><a [routerLink]="['/home']">Home</a></li>
-                     <li data-toggle="tab" [ngClass]="{'active': GetHash('solicitation')}" id="2" (click)="menuClick('/solicitation/report');"><a [routerLink]="['/solicitation/report']">Manage/Review<br/>Workload</a></li>
-                     <li data-toggle="tab" *ngIf="isGSAAdmin" [ngClass]="{'active': GetHash('analytics')}" id="3" (click)="menuClick('/analytics');"><a [routerLink]="['/analytics']" id="nav-analytics">View Analytics</a></li>
-                     <li data-toggle="tab" *ngIf="isGSAAdmin" [ngClass]="{'active': GetHash('admin')}" id="4" (click)="menuClick('/admin');"><a tabindex="{{ isGSAAdmin ? 0 : -1}}"  [routerLink]="['/admin']">Administration</a></li>
-                     <li><a target="_blank" href='https://app.buyaccessible.gov/'>Get Additional<br/>Resources</a></li>
-                     <li data-toggle="tab" [ngClass]="{'active': GetHash('contactus')}" id="5" (click)="menuClick('/help/contactus');"><a [routerLink]="['/help/contactus']">Contact Us</a></li>
-                     <li data-toggle="tab" [ngClass]="{'active': GetHash('faq')}" id="6"  (click)="menuClick('/help/faq');"><a [routerLink]="['/help/faq']"> FAQs</a></li>
-                </ul>
-
-                <div class="gsa_logo" >
-                    <div class='span-logo' >
-                        <img aria-label="GSA Logo" alt="GSA Logo" src='../../assets/gsa-logo.png'/>
-                    </div>
-                </div>
-                <ul *ngIf="isLogin" id="gsaDropdown" (keydown)="popUpMenuKey($event)" class="nav navbar-nav" style="float: right;"  >
-                    <li class="dropdown">
-                        <a *ngIf="isLogin" tabindex="0" id="menu-hello" class=""
-                                    style="font-weight: 400"
-                                    data-toggle="dropdown"
-                                    aria-haspopup="true"
-                                    aria-expanded="false"
-                                    (blur)="this.popUpMenuLostFocus()">Hello, {{firstName}}<span class="caret"></span></a>
-
-                        <ul class="dropdown-menu" role="listbox">
-                            <li>
-                              <button (blur)="this.popUpMenuLostFocus()"
-                                      id="menu-logout"
-                                      tabindex="0"
-                                      class="dropdown-item"
-                                      type="button"
-                                      style="padding: 10px 20px; font-weight:400; font-size:medium; font-family: Arial, sans-serif;"
-                                      (click)="onLogout()" role="option">Log Out</button>
-                            </li>
-                      </ul>
+                <ul *ngIf="isLogin" class="nav navbar-nav me-auto">
+                    <li class="nav-item" data-bs-toggle="tab" [ngClass]="{'active': GetHash('home')}" id="1"
+                        (click)="menuClick('/home');">
+                        <a class="nav-link" [routerLink]="['/home']">Home</a>
+                    </li>
+                    <li class="nav-item" data-bs-toggle="tab" [ngClass]="{'active': GetHash('solicitation')}" id="2"
+                        (click)="menuClick('/solicitation/report');">
+                        <a class="nav-link" [routerLink]="['/solicitation/report']">Solicitations</a>
+                    </li>
+                    <li class="nav-item" data-bs-toggle="tab" *ngIf="isGSAAdmin"
+                        [ngClass]="{'active': GetHash('analytics')}" id="3" (click)="menuClick('/analytics');">
+                        <a class="nav-link" [routerLink]="['/analytics']" id="nav-analytics">Analytics</a>
+                    </li>
+                    <li class="nav-item" data-bs-toggle="tab" *ngIf="isGSAAdmin" [ngClass]="{'active': GetHash('admin')}"
+                        id="4" (click)="menuClick('/admin');">
+                        <a class="nav-link" tabindex="{{ isGSAAdmin ? 0 : -1}}"
+                            [routerLink]="['/admin']">Administration</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" target="_blank" href='https://app.buyaccessible.gov/'>
+                            Additional Resources
+                        </a>
+                    </li>
+                    <li class="nav-item" data-bs-toggle="tab" [ngClass]="{'active': GetHash('contactus')}" id="5"
+                        (click)="menuClick('/help/contactus');">
+                        <a class="nav-link" [routerLink]="['/help/contactus']">Contact Us</a>
+                    </li>
+                    <li class="nav-item me-auto" data-bs-toggle="tab" [ngClass]="{'active': GetHash('faq')}" id="6"
+                        (click)="menuClick('/help/faq');">
+                        <a class="nav-link" [routerLink]="['/help/faq']"> FAQs</a>
                     </li>
                 </ul>
+                <ul class="nav navbar-nav">
+                    <li *ngIf="isLogin" id="gsaDropdown" class="nav-item">
+                        <a class="nav-link" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" style="font-weight: 400"> Hello, {{firstName}}<span class="caret"></span></a>
 
+                        <ul class="dropdown-menu me-5">
+                            <li>
+                                <a (blur)="this.popUpMenuLostFocus()" id="menu-logout" tabindex="0"
+                                    class="dropdown-item" type="button"
+                                    (click)="onLogout()" role="option">Log Out</a>
+                            </li>
+                        </ul>
+                    </li>
+                    <div class='span-logo'>
+                        <img aria-label="GSA Logo" alt="GSA Logo" src='../../assets/gsa-logo.png' />
+                    </div>
+                </ul>
             </div>
 
         </div>
     </nav>
     <hr style="margin: 0; height: 0;">
 </div>
-

--- a/src/app/help/contact-us/contact-us.component.html
+++ b/src/app/help/contact-us/contact-us.component.html
@@ -10,7 +10,7 @@
            to enhance SRT, we would be happy to hear from you as well. You can reach us at <b>srt@gsa.gov</b>.</p>
 
         <p>Need help determining if accessibility (Section 508) requirements apply to a solicitation, please
-           see the <a target="_blank" href="https://buyaccessible.gov/" style="color: white; text-decoration: underline;">Accessibility Requirements Tool</a>.</p>
+           see the <a target="_blank" rel="noopener noreferrer" href="https://buyaccessible.gov/" style="color: white; text-decoration: underline;">Accessibility Requirements Tool</a>.</p>
 
       </div>
     </div>

--- a/src/app/help/faq/faq.component.css
+++ b/src/app/help/faq/faq.component.css
@@ -53,6 +53,14 @@ text-align: center;
   margin-bottom: 40px;
 }
 
+.panel-heading button{
+  background: var(--surface-ground);
+}
+
+.panel-heading button:hover {
+  background: #BFDBFE;
+}
+
 .panel-body {
   font-size: 16px;
   font-weight: 500;
@@ -69,6 +77,8 @@ a.panel-link {
 a.panel-link:hover {
   text-decoration: none;
 }
+
+
 
 .panel-link:after {
   /*noinspection CssNoGenericFontName*/

--- a/src/app/help/faq/faq.component.html
+++ b/src/app/help/faq/faq.component.html
@@ -2,80 +2,78 @@
   <div class="srt-banner blue">
     <div class="container">
       <h1>Frequently Asked Questions</h1>
-      <p>Solicitation Review Tool (SRT) is an automated predictive analysis application that performs scans of the SAM.gov
+      <p>Solicitation Review Tool (SRT) is an automated predictive analysis application that performs scans of the
+        SAM.gov
         website and delivers: (1) a report containing all of the new solicitations for the previous
-        day; (2) a report of flagged solicitations that require manual review for specific regulatory requirements and compliance;
-        (3) a web-based portal for agency SMEs to perform manual reviews of flagged solicitations and to communicate with contracting
-        POCs for improvement; and (4) analytics and trending of flagged solicitations overtime by agency and government-wide.
+        day; (2) a report of flagged solicitations that require manual review for specific regulatory requirements and
+        compliance;
+        (3) a web-based portal for agency SMEs to perform manual reviews of flagged solicitations and to communicate
+        with contracting
+        POCs for improvement; and (4) analytics and trending of flagged solicitations overtime by agency and
+        government-wide.
       </p>
-      <p>SRT uses natural language processing, text mining, and machine learning algorithms to automatically identify whether
-        a solicitation contains sufficient compliance requirements for a particular use case (e.g. Section 508 Technical Requirements).
+      <p>SRT uses natural language processing, text mining, and machine learning algorithms to automatically identify
+        whether
+        a solicitation contains sufficient compliance requirements for a particular use case (e.g. Section 508 Technical
+        Requirements).
         To learn more about SRT read the FAQs below. </p>
     </div>
   </div>
 
-  <div class="container">
+  <div class="container-fluid">
 
     <div class="faq-content-div">
 
       <!-- Search FAQs by text -->
 
-      <div style="display: table; float: right">
+      <div class="pe-5" style="display: table; float: right">
         <div style="display: table-cell; vertical-align: middle">
-          <input id="search" class="search-input" placeholder="Search FAQs" (keyup)="search()" aria-label="input area to search your question">
+          <input id="search" class="search-input" placeholder="Search FAQs" (keyup)="search()"
+            aria-label="input area to search your question">
         </div>
-        <div style="display: table-cell; vertical-align: middle; cursor: pointer" (click)="search()" class="search-button">
+        <div style="display: table-cell; vertical-align: middle; cursor: pointer" (click)="search()"
+          class="search-button">
           Search
         </div>
       </div>
 
-      <div class="row nopadding" style="clear: both">
+      <div class="row px-5" style="clear: both">
 
         <!-- Left navigation -->
 
-        <div class="sticky-nav">
+        <div class="sticky-nav col-md-3">
           <ul class="usa-sidenav-list">
             <li>
-              <a tabindex="0" data-toggle="tab"
-                 (keydown.enter)="scroll('mostViewTitle')"
-                 (keydown.space)="scroll('mostViewTitle')"
-                 (click)="scroll('mostViewTitle')">Most Viewed FAQs</a>
+              <a tabindex="0" data-bs-toggle="tab" (keydown.enter)="scroll('mostViewTitle')"
+                (keydown.space)="scroll('mostViewTitle')" (click)="scroll('mostViewTitle')">Most Viewed FAQs</a>
             </li>
             <li>
-              <a tabindex="0" data-toggle="tab"
-                 (keydown.enter)="scroll('backgroundInfoTitle')"
-                 (keydown.space)="scroll('backgroundInfoTitle')"
-                 (click)="scroll('backgroundInfoTitle')">Background</a>
+              <a tabindex="0" data-bs-toggle="tab" (keydown.enter)="scroll('backgroundInfoTitle')"
+                (keydown.space)="scroll('backgroundInfoTitle')" (click)="scroll('backgroundInfoTitle')">Background</a>
             </li>
             <li>
-              <a tabindex="0" data-toggle="tab"
-                 (keydown.enter)="scroll('aboutTitle')"
-                 (keydown.space)="scroll('aboutTitle')"
-                 (click)="scroll('aboutTitle')">About SRT</a>
+              <a tabindex="0" data-bs-toggle="tab" (keydown.enter)="scroll('aboutTitle')"
+                (keydown.space)="scroll('aboutTitle')" (click)="scroll('aboutTitle')">About SRT</a>
             </li>
             <li>
-              <a tabindex="0" data-toggle="tab"
-                 (keydown.enter)="scroll('scanningProcessTitle')"
-                 (keydown.space)="scroll('scanningProcessTitle')"
-                 (click)="scroll('scanningProcessTitle')">Explore the Scanning Process</a>
+              <a tabindex="0" data-bs-toggle="tab" (keydown.enter)="scroll('scanningProcessTitle')"
+                (keydown.space)="scroll('scanningProcessTitle')" (click)="scroll('scanningProcessTitle')">Explore the
+                Scanning Process</a>
             </li>
             <li>
-              <a tabindex="0" data-toggle="tab"
-                 (keydown.enter)="scroll('accessLevelTitle')"
-                 (keydown.space)="scroll('accessLevelTitle')"
-                 (click)="scroll('accessLevelTitle')">Understand Access Privileges</a>
+              <a tabindex="0" data-bs-toggle="tab" (keydown.enter)="scroll('accessLevelTitle')"
+                (keydown.space)="scroll('accessLevelTitle')" (click)="scroll('accessLevelTitle')">Understand Access
+                Privileges</a>
             </li>
             <li>
-              <a tabindex="0" data-toggle="tab"
-                 (keydown.enter)="scroll('manageWorkloadTitle')"
-                 (keydown.space)="scroll('manageWorkloadTitle')"
-                 (click)="scroll('manageWorkloadTitle')">Manage/ Review Solicitations</a>
+              <a tabindex="0" data-bs-toggle="tab" (keydown.enter)="scroll('manageWorkloadTitle')"
+                (keydown.space)="scroll('manageWorkloadTitle')" (click)="scroll('manageWorkloadTitle')">Manage/ Review
+                Solicitations</a>
             </li>
             <li>
-              <a tabindex="0" data-toggle="tab"
-                 (keydown.enter)="scroll('requestSupportTitle')"
-                 (keydown.space)="scroll('requestSupportTitle')"
-                 (click)="scroll('requestSupportTitle')">Request Support</a>
+              <a tabindex="0" data-bs-toggle="tab" (keydown.enter)="scroll('requestSupportTitle')"
+                (keydown.space)="scroll('requestSupportTitle')" (click)="scroll('requestSupportTitle')">Request
+                Support</a>
             </li>
           </ul>
         </div>
@@ -86,16 +84,17 @@
           <div class="faq-right-content">
             <div class="search-title" *ngFor="let section of faq;">
               <h2 id="{{section.title}}">{{section.name}}</h2>
-              <div class="panel-group" id="{{section.id}}" *ngIf="section.children">
-                <div class="panel panel-default search-content" *ngFor="let element of section.children; let i = index">
-
-                  <div class="panel-heading">
-                    <a class="panel-link collapsed" data-toggle="collapse" [attr.data-parent]="'#'+section.id" href="#{{section.id}}{{i}}" >
-                      <h3 class="panel-title" style="color:black">{{element.title}}</h3>
-                    </a>
-                  </div>
-                  <div id="{{section.id}}{{i}}" class="panel-collapse collapse" >
-                    <div class="panel-body"  [innerHTML]="element.body">
+              <div class="panel-group"  *ngIf="section.children">
+                <div id="{{section.id}}" class="accordion panel panel-default search-content" *ngFor="let element of section.children; let i = index">
+                  <div class="accordion-item panel-heading">
+                    <h3 class="accordion-header panel-title" style="color:black">
+                      <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" [attr.data-bs-target]='"#"+section.id+i' aria-expanded="false" aria-controls="{{section.id}}{{i}}">
+                      {{element.title}}
+                      </button>
+                    </h3>
+                    <div id="{{section.id}}{{i}}" class="accordion-collapse collapse"  data-bs-parent="#{{section.id}}">
+                      <div class="accordion-body" [innerHTML]="element.body">
+                      </div>
                     </div>
                   </div>
                 </div>

--- a/src/app/help/faq/faq.component.html
+++ b/src/app/help/faq/faq.component.html
@@ -4,12 +4,12 @@
       <h1>Frequently Asked Questions</h1>
       <p>Solicitation Review Tool (SRT) is an automated predictive analysis application that performs scans of the
         SAM.gov
-        website and delivers: (1) a report containing all of the new solicitations for the previous
-        day; (2) a report of flagged solicitations that require manual review for specific regulatory requirements and
+        website and delivers: <strong>(1)</strong> a report containing all of the new solicitations for the previous
+        day; <strong>(2)</strong> a report of flagged solicitations that require manual review for specific regulatory requirements and
         compliance;
-        (3) a web-based portal for agency SMEs to perform manual reviews of flagged solicitations and to communicate
+        <strong>(3)</strong> a web-based portal for agency SMEs to perform manual reviews of flagged solicitations and to communicate
         with contracting
-        POCs for improvement; and (4) analytics and trending of flagged solicitations overtime by agency and
+        POCs for improvement; and <strong>(4)</strong> analytics and trending of flagged solicitations overtime by agency and
         government-wide.
       </p>
       <p>SRT uses natural language processing, text mining, and machine learning algorithms to automatically identify
@@ -33,7 +33,7 @@
         </div>
         <div style="display: table-cell; vertical-align: middle; cursor: pointer" (click)="search()"
           class="search-button">
-          Search
+          <i class="bi bi-search"></i>
         </div>
       </div>
 
@@ -88,7 +88,7 @@
                 <div id="{{section.id}}" class="accordion panel panel-default search-content" *ngFor="let element of section.children; let i = index">
                   <div class="accordion-item panel-heading">
                     <h3 class="accordion-header panel-title" style="color:black">
-                      <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" [attr.data-bs-target]='"#"+section.id+i' aria-expanded="false" aria-controls="{{section.id}}{{i}}">
+                      <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" [attr.data-bs-target]='"#"+section.id+i' aria-expanded="false" aria-controls="{{section.id}}{{i}}" style="font-weight: 600;">
                       {{element.title}}
                       </button>
                     </h3>

--- a/src/app/help/faq/faq.component.html
+++ b/src/app/help/faq/faq.component.html
@@ -26,14 +26,13 @@
 
       <!-- Search FAQs by text -->
 
-      <div class="pe-5" style="display: table; float: right">
-        <div style="display: table-cell; vertical-align: middle">
+      <div class="row px-5">
+        <div class="col-lg-11 d-flex justify-content-end">
           <input id="search" class="search-input" placeholder="Search FAQs" (keyup)="search()"
             aria-label="input area to search your question">
         </div>
-        <div style="display: table-cell; vertical-align: middle; cursor: pointer" (click)="search()"
-          class="search-button">
-          <i class="bi bi-search"></i>
+        <div style="cursor: pointer" class="search-button col-lg-1" (click)="search()">
+          <i class="bi bi-search" style="vertical-align: sub;"></i>
         </div>
       </div>
 
@@ -42,7 +41,7 @@
         <!-- Left navigation -->
 
         <div class="sticky-nav col-md-3">
-          <ul class="usa-sidenav-list">
+          <ul class="usa-sidenav-list sticky-top">
             <li>
               <a tabindex="0" data-bs-toggle="tab" (keydown.enter)="scroll('mostViewTitle')"
                 (keydown.space)="scroll('mostViewTitle')" (click)="scroll('mostViewTitle')">Most Viewed FAQs</a>

--- a/src/app/home/home/home.component.html
+++ b/src/app/home/home/home.component.html
@@ -120,7 +120,7 @@
 
         <!-- Get Additional Resources -->
         <div class="col-md-4 col-sm-6 srt-margin-bot">
-          <a target="_blank" href="https://app.buyaccessible.gov/" aria-labelledby="h3gar">
+          <a target="_blank" rel="noopener noreferrer" href="https://app.buyaccessible.gov/" aria-labelledby="h3gar">
             <div class="srt-1-1">
               <div>
                 <div class="srt-main-box">

--- a/src/app/home/home/home.component.html
+++ b/src/app/home/home/home.component.html
@@ -2,216 +2,217 @@
 
 <main id="content" class="bypass-block-target">
 
-    <div class="srt-home-head">
+  <div class="srt-home-head">
 
-      <div class="srt-head-position">
-        <div class="srt-head-text">
-          <div class="srt-head-display">
-            <div class="srt-head-padding">
-              <h1 class="srt-black srt-main-title">Solicitation Review Tool</h1>
-              <div style="font-size: 24px; font-weight:500;" class="srt-black srt-text-padding">
-                The Solicitation Review Tool (SRT) is provided to help agencies evaluate the overall solicitation compliance with accessibility,
-                cyber security, and other regulations and requirements.
-              </div>
+    <div class="srt-head-position">
+      <div class="srt-head-text">
+        <div class="srt-head-display">
+          <div class="srt-head-padding">
+            <h1 class="srt-black srt-main-title">Solicitation Review Tool</h1>
+            <div style="font-size: 24px; font-weight:500;" class="srt-black srt-text-padding">
+              The Solicitation Review Tool (SRT) is provided to help agencies evaluate the overall solicitation
+              compliance with accessibility,
+              cyber security, and other regulations and requirements.
             </div>
           </div>
         </div>
       </div>
     </div>
+  </div>
 
-    <div class="container">
-        <div style="padding: 60px 40px;">
-            <div class="row">
+  <div class="container">
+    <div style="padding: 60px 40px;">
+      <div class="row">
 
-              <!-- Review/Manage Workload -->
-              <a [routerLink]="['/solicitation/report']" aria-labelledby="h3rmw" class="orange">
-                <div class="col-md-4 col-sm-6 srt-margin-bot">
-                      <div class="srt-1-1">
-                          <div>
-                              <div class="srt-main-box" >
-                                  <!-- image -->
-                                  <div class="srt-9-20">
-                                      <div>
-                                          <div class="srt-icon-padding">
-                                              <div class="srt-icon">
-                                                <img alt="Manage/Review Workload Icon" src='/assets/review-manage-workflow.png'/>
-                                              </div>
-                                          </div>
-                                      </div>
-                                  </div>
-                                  <!-- description -->
-                                  <div class="srt-11-20">
-                                      <div>
-                                          <div class="srt-block-padding">
-                                              <h2 style="color:black" id="h3rmw">Manage/Review Workload</h2>
-                                              <p style="color:black">Access and manage solicitation review results for your agency</p>
-                                          </div>
-                                      </div>
-                                  </div>
-                              </div>
-                          </div>
-                      </div>
-                </div>
-              </a>
-
-              <!-- View Analytic -->
-              <a [routerLink]="['/analytics']" aria-labelledby="h3va">
-                <div class="col-md-4 col-sm-6 srt-margin-bot">
-                    <div class="srt-1-1">
-                      <div class="ribbon" *ngIf="isGSAAdmin==false"><span>Coming soon</span></div>
-                      <div>
-                            <div class="srt-main-box" >
-                                <!-- image -->
-                                <div class="srt-9-20">
-                                    <div>
-                                        <div class="srt-icon-padding">
-                                            <div class="srt-icon">
-                                              <img alt='view analytics icon' class="button-icon" src="/assets/view-analytics.png"/>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                                <!-- description -->
-                                <div class="srt-11-20">
-                                    <div>
-                                        <div class="srt-block-padding">
-                                            <h2 style="color:black" id="h3va">View Analytics</h2>
-                                            <p style="color:black">Visualize trend and discover insights from the analytics</p>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-              </a>
-
-              <!-- Manage SRT Access Requests -->
-              <a [routerLink]="['/admin']" aria-labelledby="h3-admin-label" *ngIf="isGSAAdmin">
-                <div class="col-md-4 col-sm-6 srt-margin-bot">
-                    <div class="srt-1-1">
-                        <div>
-                            <div class="srt-main-box">
-                                <!-- image -->
-                                <div class="srt-9-20">
-                                    <div>
-                                        <div class="srt-icon-padding">
-                                            <div class="srt-icon">
-                                              <img alt='Administration' src='/assets/manage-srt-access-requests.png' />
-
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                                <!-- description -->
-                                <div class="srt-11-20">
-                                    <div>
-                                        <div class="srt-block-padding">
-                                            <h2 style="color:black" id="h3-admin-label">Administration</h2>
-                                            <p style="color:black">View reports on user statistics, activities, and feedback.</p>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-              </a>
-
-              <!-- Get Additional Resources -->
-              <a target="_blank" href="https://app.buyaccessible.gov/" aria-labelledby="h3gar">
-                <div class="col-md-4 col-sm-6 srt-margin-bot" >
-                  <div class="srt-1-1">
+        <!-- Review/Manage Workload -->
+        <div class="col-md-4 col-sm-6 srt-margin-bot">
+          <a [routerLink]="['/solicitation/report']" aria-labelledby="h3rmw" class="orange">
+            <div class="srt-1-1">
+              <div>
+                <div class="srt-main-box">
+                  <!-- image -->
+                  <div class="srt-9-20">
                     <div>
-                      <div class="srt-main-box" >
-                        <!-- image -->
-                        <div class="srt-9-20">
-                          <div>
-                            <div class="srt-icon-padding">
-                              <div class="srt-icon">
-                                <img alt="Get Additional Resources" src="/assets/get-additional-resources.png"/>
-                              </div>
-                            </div>
-                          </div>
-                        </div>
-                        <!-- description -->
-                        <div class="srt-11-20">
-                          <div>
-                            <div class="srt-block-padding">
-                              <h2 style="color:black" id="h3gar">Get Additional Resources</h2>
-                              <p style="color:black">Need help with Accessibility requirements? Accessibility Requirements Tool can assist you with that</p>
-                            </div>
-                          </div>
+                      <div class="srt-icon-padding">
+                        <div class="srt-icon">
+                          <img alt="Manage/Review Workload Icon" src='/assets/review-manage-workflow.png' />
                         </div>
                       </div>
                     </div>
                   </div>
-                </div>
-              </a>
-
-              <!-- Contact Us -->
-              <a [routerLink]="['/help/contactus']" aria-labelledby="h3cus">
-                <div class="col-md-4 col-sm-6 srt-margin-bot" >
-                  <div class="srt-1-1">
+                  <!-- description -->
+                  <div class="srt-11-20">
                     <div>
-                      <div class="srt-main-box" >
-                        <!-- image -->
-                        <div class="srt-9-20">
-                          <div>
-                            <div class="srt-icon-padding">
-                              <div class="srt-icon">
-                                <img alt="Contact Us" src="/assets/contact-us.png"/>
-                              </div>
-                            </div>
-                          </div>
-                        </div>
-                        <!-- description -->
-                        <div class="srt-11-20">
-                          <div>
-                            <div class="srt-block-padding">
-                              <h2 style="color:black" id="h3cus">Contact Us</h2>
-                              <p style="color:black">View contact information for the Solicitation Review Tool</p>
-                            </div>
-                          </div>
-                        </div>
+                      <div class="srt-block-padding">
+                        <h2 style="color:black" id="h3rmw">Manage/Review Solicitations</h2>
+                        <p style="color:black">Access and manage solicitation review results for your agency</p>
                       </div>
                     </div>
                   </div>
                 </div>
-              </a>
-
-              <!-- FAQ -->
-              <a [routerLink]="['/help/faq']" aria-labelledby="h3faq">
-                <div class="col-md-4 col-sm-6 srt-margin-bot">
-                    <div class="srt-1-1">
-                        <div>
-                            <div class="srt-main-box">
-                                <!-- image -->
-                                <div class="srt-9-20">
-                                    <div>
-                                        <div class="srt-icon-padding">
-                                            <div class="srt-icon">
-                                              <img alt="FAQ icon" src="/assets/faq.png"/>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                                <!-- description -->
-                                <div class="srt-11-20">
-                                    <div>
-                                        <div class="srt-block-padding">
-                                            <h2 style="color:black" id="h3faq">FAQ</h2>
-                                            <p style="color:black">Review Frequently Asked Questions and learn more about SRT</p>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-              </a>
-
+              </div>
             </div>
+          </a>
         </div>
+
+        <!-- View Analytic -->
+        <div class="col-md-4 col-sm-6 srt-margin-bot">
+          <a [routerLink]="['/analytics']" aria-labelledby="h3va">
+            <div class="srt-1-1">
+              <div>
+                <div class="srt-main-box">
+                  <!-- image -->
+                  <div class="srt-9-20">
+                    <div>
+                      <div class="srt-icon-padding">
+                        <div class="srt-icon">
+                          <img alt='view analytics icon' class="button-icon" src="/assets/view-analytics.png" />
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <!-- description -->
+                  <div class="srt-11-20">
+                    <div>
+                      <div class="srt-block-padding">
+                        <h2 style="color:black" id="h3va">View Analytics</h2>
+                        <p style="color:black">Visualize trend and discover insights from the analytics</p>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </a>
+        </div>
+
+        <!-- Manage SRT Access Requests -->
+        <div class="col-md-4 col-sm-6 srt-margin-bot">
+          <a [routerLink]="['/admin']" aria-labelledby="h3-admin-label" *ngIf="isGSAAdmin">
+            <div class="srt-1-1">
+              <div>
+                <div class="srt-main-box">
+                  <!-- image -->
+                  <div class="srt-9-20">
+                    <div>
+                      <div class="srt-icon-padding">
+                        <div class="srt-icon">
+                          <img alt='Administration' src='/assets/manage-srt-access-requests.png' />
+
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <!-- description -->
+                  <div class="srt-11-20">
+                    <div>
+                      <div class="srt-block-padding">
+                        <h2 style="color:black" id="h3-admin-label">Administration</h2>
+                        <p style="color:black">View reports on user statistics, activities, and feedback.</p>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </a>
+        </div>
+
+        <!-- Get Additional Resources -->
+        <div class="col-md-4 col-sm-6 srt-margin-bot">
+          <a target="_blank" href="https://app.buyaccessible.gov/" aria-labelledby="h3gar">
+            <div class="srt-1-1">
+              <div>
+                <div class="srt-main-box">
+                  <!-- image -->
+                  <div class="srt-9-20">
+                    <div>
+                      <div class="srt-icon-padding">
+                        <div class="srt-icon">
+                          <img alt="Get Additional Resources" src="/assets/get-additional-resources.png" />
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <!-- description -->
+                  <div class="srt-11-20">
+                    <div>
+                      <div class="srt-block-padding">
+                        <h2 style="color:black" id="h3gar">Get Additional Resources</h2>
+                        <p style="color:black">Need help with Accessibility requirements? Accessibility Requirements
+                          Tool can assist you with that</p>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </a>
+        </div>
+
+        <!-- Contact Us -->
+        <div class="col-md-4 col-sm-6 srt-margin-bot">
+          <a [routerLink]="['/help/contactus']" aria-labelledby="h3cus">
+            <div class="srt-1-1">
+              <div>
+                <div class="srt-main-box">
+                  <!-- image -->
+                  <div class="srt-9-20">
+                    <div>
+                      <div class="srt-icon-padding">
+                        <div class="srt-icon">
+                          <img alt="Contact Us" src="/assets/contact-us.png" />
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <!-- description -->
+                  <div class="srt-11-20">
+                    <div>
+                      <div class="srt-block-padding">
+                        <h2 style="color:black" id="h3cus">Contact Us</h2>
+                        <p style="color:black">View contact information for the Solicitation Review Tool</p>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </a>
+        </div>
+
+
+        <!-- FAQ -->
+        <div class="col-md-4 col-sm-6 srt-margin-bot">
+          <a [routerLink]="['/help/faq']" aria-labelledby="h3faq">
+            <div class="srt-1-1">
+              <div>
+                <div class="srt-main-box">
+                  <!-- image -->
+                  <div class="srt-9-20">
+                    <div>
+                      <div class="srt-icon-padding">
+                        <div class="srt-icon">
+                          <img alt="FAQ icon" src="/assets/faq.png" />
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <!-- description -->
+                  <div class="srt-11-20">
+                    <div>
+                      <div class="srt-block-padding">
+                        <h2 style="color:black" id="h3faq">FAQ</h2>
+                        <p style="color:black">Review Frequently Asked Questions and learn more about SRT</p>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </a>
+        </div>
+      </div>
     </div>
-  </main>
+  </div>
+</main>

--- a/src/app/solicitation/feedback-report/form/form.component.html
+++ b/src/app/solicitation/feedback-report/form/form.component.html
@@ -1,8 +1,8 @@
 <!-- <a [routerLink]="['/solicitation/report/', solicitation._id]">{{solicitation.title}}</a> -->
 <div class="container">
-  <div class="clearfix impcontainer">
+  <div class="clearfix impcontainer pt-3">
     <div class="imppostion">
-      <div style="padding-bottom: 20px;">
+      <div class="pb-3">
         <div class="list">
           <div class="list-title" style="width: 120px">Solicitation Title:&nbsp;</div>
           <div class="list-content">{{title}}</div>

--- a/src/app/solicitation/solicitation-report/solicitation-report.component.html
+++ b/src/app/solicitation/solicitation-report/solicitation-report.component.html
@@ -18,14 +18,14 @@
   </div>
 
   <div *ngIf="solicitations">
-    <div class="row nopadding py-3">
+    <div class="row nopadding py-4">
       <div class="ps-5 col-8">
         <h1 class="srt-page-title srt-blue" style="padding-bottom: 5px;" role="heading" aria-level="1">Solicitation
           Review Results for Section 508 Requirements</h1>
       </div>
         <!--
            <div class="epa-toggle">
-             Show solicitaitons related to:
+             Show solicitations related to:
              <select>
                <option>All</option>
                <option>Information Technology</option>

--- a/src/app/solicitation/solicitation-report/solicitation-report.component.html
+++ b/src/app/solicitation/solicitation-report/solicitation-report.component.html
@@ -1,28 +1,29 @@
 <main id="content" class="bypass-block-target">
-<div *ngIf="!solicitations" class="solic-nosolic">
+  <div *ngIf="!solicitations" class="solic-nosolic">
     <div class="solic-nosolic-posi" id="loading">
-        <ul class="cb-slide-show">
-            <i class="fa fa-cog fa-spin" style="color: #4a4a4a"></i>
-            <li><span>L</span></li>
-            <li><span>O</span></li>
-            <li><span>A</span></li>
-            <li><span>D</span></li>
-            <li><span>I</span></li>
-            <li><span>N</span></li>
-            <li><span>G</span></li>
-            <li><span>.</span></li>
-            <li><span>.</span></li>
-            <li><span>.</span></li>
-        </ul>
+      <ul class="cb-slide-show">
+        <i class="fa fa-cog fa-spin" style="color: #4a4a4a"></i>
+        <li><span>L</span></li>
+        <li><span>O</span></li>
+        <li><span>A</span></li>
+        <li><span>D</span></li>
+        <li><span>I</span></li>
+        <li><span>N</span></li>
+        <li><span>G</span></li>
+        <li><span>.</span></li>
+        <li><span>.</span></li>
+        <li><span>.</span></li>
+      </ul>
     </div>
-</div>
+  </div>
 
-<div *ngIf="solicitations">
-    <div class="row nopadding">
-        <div style="padding-left: 5em" class="clearfix">
-            <h1 class="srt-page-title srt-blue" style="padding-bottom: 5px;"  role="heading" aria-level="1">Solicitation Review Results for Section 508 Requirements</h1>
-
-          <!--
+  <div *ngIf="solicitations">
+    <div class="row nopadding py-3">
+      <div class="ps-5 col-8">
+        <h1 class="srt-page-title srt-blue" style="padding-bottom: 5px;" role="heading" aria-level="1">Solicitation
+          Review Results for Section 508 Requirements</h1>
+      </div>
+        <!--
            <div class="epa-toggle">
              Show solicitaitons related to:
              <select>
@@ -32,122 +33,113 @@
              </select>
            </div>
           -->
-            <div class="solic-table">
-                    <div class="solic-keyword">
-                    <label id="ksearch-label" for="ksearch" class="solic-keyword">Search all table content:
-                            <!--<span class="input-invalid" *ngIf="errorMessage && (myForm.value.email == null || myForm.value.email == '')">Please fill in requred field</span>-->
-                    </label>
-                    </div>
-                <!-- <div class="solic-keyword">Keyword Search:</div> -->
-                <div class="solic-table-cell">
-                    <div class="input-group" id="solsearch">
-                        <span class="input-group-btn">
-                            <button class="btn btn-primary" type="button" role="presentation" tabindex="-1">
-                                <span class=" glyphicon glyphicon-search"></span>
-                            </button>
-                        </span>
-                        <input pInputText id="ksearch"
-                               type="text"
-                               class="search-query form-control"
-                               placeholder="search string"
-                               (input)="gb.filterGlobal($event.target.value, 'contains')"
-                        />
-                    </div>
-                </div>
-                <div class="solic-export"><div style="padding: 0 0 0 15px;">Export As:</div></div>
-                <div class="solic-export-cursor">
-                    <img tabindex="0" id="csvlogo" aria-label="export as csv" alt="export as csv" src="../../../assets/downloadcsv.jpeg" style="float:left" (keydown.enter)="exportCSV({})"  (click)="exportCSV({})">
-                </div>
-            </div>
-
-
-                <!-- <div class="solic-littlescan" role="heading" aria-level="2">Last scanned date: {{dateScan}}</div> -->
-            </div>
+      <div class="solic-table col-4 ps-5">
+        <!-- <div class="solic-keyword">Keyword Search:</div> -->
+        <div class="solic-table-cell">
+          <div class="input-group" id="solsearch">
+            <span class="input-group-btn pe-2">
+              <button class="btn btn-primary" type="button" role="presentation" tabindex="-1">
+                <i class="bi bi-search"></i>
+              </button>
+            </span>
+            <input pInputText id="ksearch" type="text" class="search-query form-control" placeholder="Search all table content"
+              (input)="gb.filterGlobal($event.target.value, 'contains')" />
+          </div>
         </div>
+        <div class="solic-export">
+          <div style="padding: 0 0 0 15px;">Export As:</div>
+        </div>
+        <div class="solic-export-cursor">
+          <img tabindex="0" id="csvlogo" aria-label="export as csv" alt="export as csv"
+            src="../../../assets/downloadcsv.jpeg" style="float:left" (keydown.enter)="exportCSV({})"
+            (click)="exportCSV({})">
+        </div>
+      </div>
 
 
-  <p-table #gb styleClass="pDataTable p-datatable-gridlines"
-           [value]="solicitations"
-           [lazy] = "true"
-           [loading]="loading"
-           (onPage)="stageChange($event)"
-           (onFilter)="filterChange()"
-           (onSort)="stageChange($event)"
-           [(first)]="tableState.first"
-           sortField="{{tableState.sort.field}}"
-           sortOrder="{{tableState.sort.order}}"
-           (onLazyLoad)="loadSolicitationsLazy($event)"
-           [totalRecords]="totalRecordCount"
-           [rows]="15"
-           [paginator]="true"
-           [rowsPerPageOptions]="[15, 25, 35, 45]"
-           [pageLinks]="4"
-           [resizableColumns]="false"
-           [columns]="columns"
-           [globalFilterFields]="['solNum', 'title', 'date', 'actionDate', 'agency', 'office']"
-           >
-    <ng-template pTemplate="header">
-      <tr>
-        <th *ngFor="let col of columns" [pSortableColumn]="col.field" [id]="col.field" [ngSwitch]="col.field" pResizableColumn>
-          {{col.title}}
+        <!-- <div class="solic-littlescan" role="heading" aria-level="2">Last scanned date: {{dateScan}}</div> -->
+    </div>
 
-          <p-sortIcon *ngIf="col.field !== undefined"
-                      [field]="col.field"
-                      ariaLabel="Activate to sort"
-                      ariaLabelDesc="Activate to sort in descending order"
-                      ariaLabelAsc="Activate to sort in ascending order">
-                    </p-sortIcon>
-          <br>
-          <br>
-          <p-dropdown id="ddl_noticeTypes" *ngSwitchCase="'noticeType'" [options]="noticeTypes" [(ngModel)]="noticeTypeFilterModel"
-                      (onChange)="gb.filter($event.value, col.field, 'equals')"></p-dropdown>
 
-          <p-dropdown id="ddl_reviewRec" *ngSwitchCase="'reviewRec'" [options]="reviewRec" [(ngModel)]="reviewResultFilterModel"
-                      (onChange)="gb.filter($event.value, col.field, 'equals')" 
-                      (onLazyLoad)="gb.filter($event.value, col.field, 'equals')"
-                      ></p-dropdown>
+    <p-table #gb styleClass="pDataTable p-datatable-gridlines" [value]="solicitations" [lazy]="true" [loading]="loading"
+      (onPage)="stageChange($event)" (onFilter)="filterChange()" (onSort)="stageChange($event)"
+      [(first)]="tableState.first" sortField="{{tableState.sort.field}}" sortOrder="{{tableState.sort.order}}"
+      (onLazyLoad)="loadSolicitationsLazy($event)" [totalRecords]="totalRecordCount" [rows]="15" [paginator]="true"
+      [rowsPerPageOptions]="[15, 25, 35, 45]" [pageLinks]="4" [resizableColumns]="false" [columns]="columns"
+      [globalFilterFields]="['solNum', 'title', 'date', 'actionDate', 'agency', 'office']">
+      <ng-template pTemplate="header">
+        <tr>
+          <th *ngFor="let col of columns" [pSortableColumn]="col.field" [id]="col.field" [ngSwitch]="col.field"
+            pResizableColumn>
+            {{col.title}}
 
-          <p-dropdown id="ddl_predictions.estar" *ngSwitchCase="'predictions.estar'" [options]="epaDropdown"
-                      (onChange)="gb.filter($event.value, col.field, 'equals')"></p-dropdown>
+            <p-sortIcon *ngIf="col.field !== undefined" [field]="col.field" ariaLabel="Activate to sort"
+              ariaLabelDesc="Activate to sort in descending order" ariaLabelAsc="Activate to sort in ascending order">
+            </p-sortIcon>
+            <br>
+            <br>
+            <p-dropdown id="ddl_noticeTypes" *ngSwitchCase="'noticeType'" [options]="noticeTypes"
+              [(ngModel)]="noticeTypeFilterModel"
+              (onChange)="gb.filter($event.value, col.field, 'equals')"></p-dropdown>
 
-        </th>
-      </tr>
-    </ng-template>
-    <ng-template pTemplate="body" let-sol>
-      <tr (mousedown)="mouseDown(sol)" (mouseup)="mouseUp(sol)">
-        <td class="p-resizable-column srt-table-data col_solicitation"><span class="p-column-title">Solicitation #</span><a href={{sol.url}}>{{sol.solNum}}</a></td>
-        <td class="p-resizable-column srt-table-data col_title"><span class="p-column-title">Title</span>{{sol.title}}</td>
-        <td class="p-resizable-column srt-table-data col_notice_type"><span class="p-column-title">Notice Type</span>{{sol.noticeType}}</td>
-        <td class="p-resizable-column srt-table-data col_date_posted"><span class="p-column-title">Date Posted</span>{{sol.date}}</td>
-        <td class="p-resizable-column srt-table-data col_review_result">
-          <span class="p-column-title">Review Result</span>
-          <button class="button {{'result-' + ((sol.reviewRec == 'Not Applicable') ? 'black' : sol.predictions.value)}}" (click)="selectSol(sol)"  style="border: none; text-align: left; padding: 0;">
-              <i class="fa fa-exclamation-triangle" style="padding-right: 5px;" *ngIf="sol.predictions.value == 'red' && sol.reviewRec != 'Not Applicable'"></i>
-            <span style="text-decoration: underline;">{{sol.reviewRec}}</span>
-          </button>
-        </td>
-        <td class="p-resizable-column srt-table-data col_review_result" *ngIf="feature_flags.estar">
-          <span class="p-column-title">EPA Review</span>
-          <button class="button {{'result-' + sol.predictions.estar}}" (click)="selectSol(sol)"  style="border: none; text-align: left; padding: 0;">
-            <i class="fa fa-exclamation-triangle" style="padding-right: 5px;" *ngIf="sol.predictions.estar == 'red' "></i>
-            <span style="">{{sol.predictions.estar == "green" ? "Compliant" :
-                             sol.predictions.estar == "red" ? "Non-compliant" :
-                             sol.predictions.estar == "Not Applicable" ? "Not Applicable" :  ""}}</span>
-          </button>
-        </td>
-        <td class="p-resizable-column srt-table-data col_action_status"><span class="p-column-title">Action Status</span>{{sol.actionStatus}}</td>
-        <td class="p-resizable-column srt-table-data col_action_date"><span class="p-column-title">Action Date</span>{{sol.actionDate}}</td>
-        <td class="p-resizable-column srt-table-data col_agency"><span class="p-column-title">Agency</span>{{sol.agency}}</td>
-        <td class="p-resizable-column col_url" hidden><span class="p-column-title">URL</span>{{sol.url}}</td>
-        <td class="p-resizable-column srt-table-data col_office"><span class="p-column-title">Office</span>{{sol.office}}</td>
-      </tr>
-    </ng-template>
+            <p-dropdown id="ddl_reviewRec" *ngSwitchCase="'reviewRec'" [options]="reviewRec"
+              [(ngModel)]="reviewResultFilterModel" (onChange)="gb.filter($event.value, col.field, 'equals')"
+              (onLazyLoad)="gb.filter($event.value, col.field, 'equals')"></p-dropdown>
 
-  </p-table>
-  
-  <div id="total-count">
-    Total Solicitation {{totalRecordCount}}
+            <p-dropdown id="ddl_predictions.estar" *ngSwitchCase="'predictions.estar'" [options]="epaDropdown"
+              (onChange)="gb.filter($event.value, col.field, 'equals')"></p-dropdown>
+
+          </th>
+        </tr>
+      </ng-template>
+      <ng-template pTemplate="body" let-sol>
+        <tr (mousedown)="mouseDown(sol)" (mouseup)="mouseUp(sol)">
+          <td class="p-resizable-column srt-table-data col_solicitation"><span class="p-column-title">Solicitation
+              #</span><a href={{sol.url}} target="_blank" rel="noopener noreferrer">{{sol.solNum}}</a></td>
+          <td class="p-resizable-column srt-table-data col_title"><span class="p-column-title">Title</span>{{sol.title}}
+          </td>
+          <td class="p-resizable-column srt-table-data col_notice_type"><span class="p-column-title">Notice
+              Type</span>{{sol.noticeType}}</td>
+          <td class="p-resizable-column srt-table-data col_date_posted"><span class="p-column-title">Date
+              Posted</span>{{sol.date}}</td>
+          <td class="p-resizable-column srt-table-data col_review_result">
+            <span class="p-column-title">Review Result</span>
+            <button
+              class="button {{'result-' + ((sol.reviewRec == 'Not Applicable') ? 'black' : sol.predictions.value)}}"
+              (click)="selectSol(sol)" style="border: none; text-align: left; padding: 0;">
+              <i class="fa fa-exclamation-triangle" style="padding-right: 5px;"
+                *ngIf="sol.predictions.value == 'red' && sol.reviewRec != 'Not Applicable'"></i>
+              <span style="text-decoration: underline;">{{sol.reviewRec}}</span>
+            </button>
+          </td>
+          <td class="p-resizable-column srt-table-data col_review_result" *ngIf="feature_flags.estar">
+            <span class="p-column-title">EPA Review</span>
+            <button class="button {{'result-' + sol.predictions.estar}}" (click)="selectSol(sol)"
+              style="border: none; text-align: left; padding: 0;">
+              <i class="fa fa-exclamation-triangle" style="padding-right: 5px;"
+                *ngIf="sol.predictions.estar == 'red' "></i>
+              <span style="">{{sol.predictions.estar == "green" ? "Compliant" :
+                sol.predictions.estar == "red" ? "Non-compliant" :
+                sol.predictions.estar == "Not Applicable" ? "Not Applicable" : ""}}</span>
+            </button>
+          </td>
+          <td class="p-resizable-column srt-table-data col_action_status"><span class="p-column-title">Action
+              Status</span>{{sol.actionStatus}}</td>
+          <td class="p-resizable-column srt-table-data col_action_date"><span class="p-column-title">Action
+              Date</span>{{sol.actionDate}}</td>
+          <td class="p-resizable-column srt-table-data col_agency"><span
+              class="p-column-title">Agency</span>{{sol.agency}}</td>
+          <td class="p-resizable-column col_url" hidden><span class="p-column-title">URL</span>{{sol.url}}</td>
+          <td class="p-resizable-column srt-table-data col_office"><span
+              class="p-column-title">Office</span>{{sol.office}}</td>
+        </tr>
+      </ng-template>
+
+    </p-table>
+
+    <div id="total-count">
+      Total Solicitation {{totalRecordCount}}
+    </div>
+
   </div>
-
-</div>
 </main>

--- a/src/app/solicitation/summary/email-poc/email-poc.component.css
+++ b/src/app/solicitation/summary/email-poc/email-poc.component.css
@@ -15,6 +15,9 @@ input.form-control {
 
 label {
     width: 65px;
+    margin-bottom: 5px;
+    display: inline-block;
+    font-weight: 700;
 }
 
 .ql-toolbar.ql-snow {

--- a/src/app/solicitation/summary/email-poc/email-poc.component.html
+++ b/src/app/solicitation/summary/email-poc/email-poc.component.html
@@ -40,41 +40,57 @@
 
 
             <div id="form-div">
-              <div class="form-group">
-                <label>To:</label>
-                {{emailTo}}
-                <button (click)="copyText('emailTo')" class="srt-button">
-                  Copy Email &nbsp;<i class="fa fa-copy" ></i>
-                </button>
+              <div class="row form-group">
+                <div class="col-lg-10 col-md-10 col-sm-6">
+                  <label>To:</label>
+                  {{emailTo}}
+                </div>
+                <div class="col-lg-2 col-md-2 col-sm-6">
+                  <button (click)="copyText('emailTo')" class="srt-button">
+                    Copy Email &nbsp;<i class="fa fa-copy" ></i>
+                  </button>
+                </div>
               </div>
 
-              <div class="form-group" *ngIf="this.templateToShow == 'IT Language'">
-                <label>Subject:</label>
-                {{subject}}
-                <button (click)="copyText('subject')" class="srt-button">
-                  Copy Subject &nbsp;<i class="fa fa-copy" ></i>
-                </button>
+              <div class="row form-group" *ngIf="this.templateToShow == 'IT Language'">
+                <div class="col-lg-10 col-md-10 col-sm-6">
+                  <label>Subject:</label>
+                  {{subject}}
+                </div>
+                <div class="col-lg-2 col-md-2 col-sm-6">
+                  <button (click)="copyText('subject')" class="srt-button">
+                    Copy Subject &nbsp;<i class="fa fa-copy" ></i>
+                  </button>
+                </div>
               </div>
 
-              <div class="form-group" *ngIf="this.templateToShow == 'EPA Language'">
-                <label>Subject:</label>
-                {{epaSubject}}
-                <button (click)="copyText('epaSubject')" class="srt-button">
-                  Copy Subject &nbsp;<i class="fa fa-copy" ></i>
-                </button>
+              <div class="row form-group" *ngIf="this.templateToShow == 'EPA Language'">
+                <div class="col-lg-10 col-md-10 col-sm-6">
+                  <label>Subject:</label>
+                  {{epaSubject}}
+                </div>
+                <div class="col-lg-2 col-md-2 col-sm-6">
+                  <button (click)="copyText('epaSubject')" class="srt-button">
+                    Copy Subject &nbsp;<i class="fa fa-copy" ></i>
+                  </button>
+                </div>
               </div>
 
-              <div class="form-group">
-                <label for="it_message">Message:</label>
-                <button (click)="copyText('it_message')" class="srt-button" *ngIf="this.templateToShow == 'IT Language'">
-                  Copy Message &nbsp;<i class="fa fa-copy" ></i>
-                </button>
-                <button (click)="copyText('epa_message')" class="srt-button" *ngIf="this.templateToShow == 'EPA Language'">
+              <div class="row form-group">
+                <div class="col-lg-10 col-md-10 col-sm-6">
+                  <label for="it_message">Message:</label>
+                </div>
+                <div class="col-lg-2 col-md-2 col-sm-6">
+                  <button (click)="copyText('it_message')" class="srt-button" *ngIf="this.templateToShow == 'IT Language'">
                     Copy Message &nbsp;<i class="fa fa-copy" ></i>
-                </button>
+                  </button>
+                  <button (click)="copyText('epa_message')" class="srt-button" *ngIf="this.templateToShow == 'EPA Language'">
+                      Copy Message &nbsp;<i class="fa fa-copy" ></i>
+                  </button>
+                </div>
               </div>
 
-              <div>
+              <div class="pt-3">
                 <quill-editor id="it_message"
                               style="min-height: calc(100vh - 585px)"
                               formControlName="it_message" [options]="editorOptions"
@@ -83,7 +99,7 @@
                 ></quill-editor>
               </div>
 
-              <div>
+              <div class="pt-3">
                 <quill-editor id="epa_message"
                               style="min-height: calc(100vh - 585px)"
                               formControlName="epa_message" [options]="editorOptions"

--- a/src/app/solicitation/summary/email-poc/email-poc.component.ts
+++ b/src/app/solicitation/summary/email-poc/email-poc.component.ts
@@ -81,7 +81,7 @@ export class EmailPocComponent implements OnInit {
                 }
               });
             } else {
-              console.log ('Error processing parse status for solicitaiton ' + data.solNum);
+              console.log ('Error processing parse status for solicitation ' + data.solNum);
               data.parseStatus = [{formattedDate: '', postedDate: null, name: '', status: '', attachment_url: ''}];
             }
             this.emailSent = data.history.filter(function(e){return ((e['action'].indexOf('sent email to POC') > -1) ); }).length > 0;

--- a/src/app/solicitation/summary/help-us-improve/help-us-improve.component.html
+++ b/src/app/solicitation/summary/help-us-improve/help-us-improve.component.html
@@ -55,7 +55,7 @@
               </div>
               <div class="list">
                 <div class="list-title" style="width: 68px">SAM.gov Link:&nbsp;</div>
-                <div class="list-content"><a href="{{solicitation.url}}" target="_blank">{{solicitation.url}}</a></div>
+                <div class="list-content"><a href="{{solicitation.url}}" target="_blank" rel="noopener noreferrer">{{solicitation.url}}</a></div>
               </div>
               <div class="list">
                 <div class="list-title" style="width: 130px">Prediction Results:&nbsp; </div>

--- a/src/app/solicitation/summary/help-us-improve/help-us-improve.component.html
+++ b/src/app/solicitation/summary/help-us-improve/help-us-improve.component.html
@@ -39,9 +39,9 @@
         </div>
 
 
-        <div *ngIf="solicitation" class="clearfix impcontainer">
+        <div *ngIf="solicitation" class="clearfix impcontainer pt-3">
           <div class="imppostion">
-            <div style="padding-bottom: 20px;">
+            <div class="pb-3">
               <h2 class="srt-section-title" style="text-transform: uppercase; padding-bottom: 20px;">
                 solicitation review result
               </h2>

--- a/src/app/solicitation/summary/help-us-improve/help-us-improve.component.ts
+++ b/src/app/solicitation/summary/help-us-improve/help-us-improve.component.ts
@@ -67,7 +67,7 @@ export class HelpUsImproveComponent implements OnInit {
                 }
               });
             } else {
-              console.log ('Error processing parse status for solicitaiton ' + data.solNum);
+              console.log ('Error processing parse status for solicitation ' + data.solNum);
               data.parseStatus = [{formattedDate: '', postedDate: null, name: '', status: '', attachment_url: ''}];
             }
 

--- a/src/app/solicitation/summary/results-detail/results-detail.component.css
+++ b/src/app/solicitation/summary/results-detail/results-detail.component.css
@@ -38,7 +38,14 @@ font-size: 16px;
   outline: 0.25rem solid #2491ff;
   color: #1b1b1b;
   float: left;
-  width: 300px;
+  width: auto;
+  font-weight: bold;
+}
+
+  #art:hover {
+    background-color: #c05600;
+    color: white;
+    font-weight: bold;
   }
 
 .summary-content-padding{

--- a/src/app/solicitation/summary/results-detail/results-detail.component.html
+++ b/src/app/solicitation/summary/results-detail/results-detail.component.html
@@ -25,8 +25,8 @@
             </div>
             <div class="row">
               <div class="col-md-8">
-                <a href="https://section508.gov/art" target="_blank">
-                  <div id="art" class="srt-button" rel="noopener noreferrer">
+                <a href="https://section508.gov/art" target="_blank"  rel="noopener noreferrer">
+                  <div id="art" class="srt-button">
                     <div>
                       Take Action: Get 508 Requirements
                     </div>

--- a/src/app/solicitation/summary/results-detail/results-detail.component.html
+++ b/src/app/solicitation/summary/results-detail/results-detail.component.html
@@ -17,7 +17,7 @@
         <div class="col-md-8 col-sm-12">
           <div style="display: inline-block; font-weight: 500" *ngIf="solicitation">
             <div style="font-size: 24px; padding-bottom: 15px;">{{solicitation.title}}</div>
-            <div style="padding-bottom: 5px"><a target="_blank" href="{{solicitation.url}}">{{solicitation.url}}</a></div>
+            <div style="padding-bottom: 5px"><a target="_blank" href="{{solicitation.url}}" rel="noopener noreferrer">{{solicitation.url}}</a></div>
             <div *ngIf="solicitation.reviewRec !== 'Not Applicable' " style="padding-bottom: 5px">
               <span style="font-weight:600">Results:&nbsp;</span>
               <span style="font-weight:500" >{{solicitation.reviewRec}}</span>

--- a/src/app/solicitation/summary/results-detail/results-detail.component.html
+++ b/src/app/solicitation/summary/results-detail/results-detail.component.html
@@ -23,14 +23,10 @@
               <span style="font-weight:500" >{{solicitation.reviewRec}}</span>                    
             <!-- insert button here for linking to ART -->
             </div>
-            <div class="row">
+            <div class="row pt-2">
               <div class="col-md-8">
-                <a href="https://section508.gov/art" target="_blank"  rel="noopener noreferrer">
-                  <div id="art" class="srt-button">
-                    <div>
-                      Take Action: Get 508 Requirements
-                    </div>
-                  </div>
+                <a id="art" href="https://section508.gov/art" target="_blank"  rel="noopener noreferrer" class="btn srt-button">
+                  Take Action: Get 508 Requirements
                 </a>
               </div>
             </div>

--- a/src/app/solicitation/summary/results-detail/results-detail.component.ts
+++ b/src/app/solicitation/summary/results-detail/results-detail.component.ts
@@ -72,7 +72,7 @@ export class ResultsDetailComponent implements OnInit {
                 element.formattedDate = moment(element.postedDate).format('L');
               });
             } else {
-              console.log ('Error processing parse status for solicitaiton ' + data.solNum);
+              console.log ('Error processing parse status for solicitation ' + data.solNum);
               data.parseStatus = [{formattedDate: '', postedDate: null, name: '', status: '', attachment_url: ''}];
             }
 

--- a/src/app/solicitation/summary/summary.component.html
+++ b/src/app/solicitation/summary/summary.component.html
@@ -20,8 +20,8 @@
         </ul>
     </div>
 </div>
-<div class="srt-tabs summary-tab">
-    <div class="container">
+<div class="row srt-tabs">
+    <div class="container px-5">
         <div ng-if="showActivitySelection()" role="navigation" aria-label="step navigation">
 
             <ul class="nopadding summary-floatleft" >

--- a/src/app/user/masq/masq.component.html
+++ b/src/app/user/masq/masq.component.html
@@ -7,19 +7,19 @@
       <div>
         <form [formGroup]="masqForm" (ngSubmit)="onSubmit(masqForm)">
           <div class="row">
-            <div class="col-xs-2" style="text-align: right">
+            <div class="col-lg-2 col-md-2 col-sm-2 col-xs-2" style="text-align: right">
               <label for="agency">Agency:</label>
             </div>
-            <div class="col-xs-10">
+            <div class="col-lg-10 col-md-10 col-sm-10 col-xs-10">
               <input placeholder="" formControlName="agency" id="agency"/>
             </div>
           </div>
 
           <div class="row" style="padding-top: 10px;">
-            <div class="col-xs-2" style="text-align: right">
+            <div class="col-lg-2 col-md-2 col-sm-2 col-xs-2" style="text-align: right">
               <label for="role">User type:</label>
             </div>
-            <div class="col-xs-10">
+            <div class="col-lg-10 col-md-10 col-sm-10 col-xs-10">
               <select placeholder="Just a placeholder" formControlName="role" id="role">
                 <option value="Administrator">GSA Admin</option>
                 <option value="SRT Program Manager">SRT Admin</option>
@@ -31,7 +31,7 @@
           </div>
 
           <div class="row" style="padding-top: 10px;">
-            <div class="col-xs-2" style="text-align: right">
+            <div class="col-lg-2 col-md-2 col-sm-2 col-xs-2" style="text-align: right">
               <button type="submit">Submit</button>
             </div>
           </div>

--- a/src/index.html
+++ b/src/index.html
@@ -26,7 +26,7 @@
   <app-root>Loading...</app-root>
 
   <!-- Latest compiled and minified JavaScript -->
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" integrity="sha384-geWF76RCwLtnZ8qwWowPQNguL3RmwHVBC9FhGdlKrxdiJJigb/j/68SIy3Te4Bkz" crossorigin="anonymous"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" integrity="sha384-geWF76RCwLtnZ8qwWowPQNguL3RmwHVBC9FhGdlKrxdiJJigb/j/68SIy3Te4Bkz" crossorigin="anonymous"></script>
   <script src="https://use.fontawesome.com/22ad9bb71f.js"></script>
 
 

--- a/src/index.html
+++ b/src/index.html
@@ -9,10 +9,11 @@
   <link rel="icon" type="image/x-icon" href="favicon.ico">
 
   <!-- Latest compiled and minified CSS -->
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@3.4.1/dist/css/bootstrap.min.css" integrity="sha384-HSMxcRTRxnN+Bdg0JdbxYKrThecOKuH5zCYotlSAcp1+c8xmyTe9GYg1l9a69psu" crossorigin="anonymous">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-9ndCyUaIbzAi2FUVXJi0CjmCapSmO7SnpJef0486qhLnuZ2cdeRhO02iuK6FUUVM" crossorigin="anonymous">
+  
+  <!-- Bootstrap Icons -->
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">
 
-<!-- Optional theme -->
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@3.4.1/dist/css/bootstrap-theme.min.css" integrity="sha384-6pzBo3FDv/PJ8r2KRkGHifhEocL+1X2rVCTTkUfGk7/0pbek5mMa1upzvWbrUbOZ" crossorigin="anonymous">
   <script>
       __Zone_enable_cross_context_check = true;
   </script>
@@ -24,9 +25,8 @@
 <body>
   <app-root>Loading...</app-root>
 
-  <script src="https://cdn.jsdelivr.net/npm/jquery@3.5.1/dist/jquery.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
   <!-- Latest compiled and minified JavaScript -->
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@3.4.1/dist/js/bootstrap.min.js" integrity="sha384-aJ21OjlMXNL5UyIl/XNwTMqvzeRMZH2w8c5cRVpzpU8Y5bApTppSuUkhZXN0VxHd" crossorigin="anonymous"></script>  
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" integrity="sha384-geWF76RCwLtnZ8qwWowPQNguL3RmwHVBC9FhGdlKrxdiJJigb/j/68SIy3Te4Bkz" crossorigin="anonymous"></script>
   <script src="https://use.fontawesome.com/22ad9bb71f.js"></script>
 
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -411,3 +411,8 @@ body .p-datatable .p-datatable-tbody > tr > td {
 .ql-snow a {
   color: #112e51 !important;
 }
+
+
+.panel-heading button:hover {
+  background: #BFDBFE;
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -413,6 +413,3 @@ body .p-datatable .p-datatable-tbody > tr > td {
 }
 
 
-.panel-heading button:hover {
-  background: #BFDBFE;
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,26 +10,13 @@
     "@jridgewell/gen-mapping" "^0.1.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@ampproject/remapping@2.2.1", "@ampproject/remapping@^2.1.0", "@ampproject/remapping@^2.2.0":
+"@ampproject/remapping@^2.1.0", "@ampproject/remapping@^2.2.0":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@ampproject/remapping/-/remapping-2.2.1.tgz#99e8e11851128b8702cd57c33684f1d0f260b630"
   integrity sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==
   dependencies:
     "@jridgewell/gen-mapping" "^0.3.0"
     "@jridgewell/trace-mapping" "^0.3.9"
-
-"@angular-builders/custom-webpack@^16.0.0":
-  version "16.0.0"
-  resolved "https://registry.yarnpkg.com/@angular-builders/custom-webpack/-/custom-webpack-16.0.0.tgz#2930cf38ab891c0bb78d4191252b256fd4c0c460"
-  integrity sha512-CR2529DueVpYhS4hPm0TDm4sDeSzYKn+4IvFmujciy4uSO8W4YrBmRgSM0YKjHRGeIwwlHRy025lLjjT7XAPdQ==
-  dependencies:
-    "@angular-devkit/architect" ">=0.1600.0 < 0.1700.0"
-    "@angular-devkit/build-angular" "^16.0.0"
-    "@angular-devkit/core" "^16.0.0"
-    lodash "^4.17.15"
-    ts-node "^10.0.0"
-    tsconfig-paths "^4.1.0"
-    webpack-merge "^5.7.3"
 
 "@angular-devkit/architect@0.1002.4":
   version "0.1002.4"
@@ -46,14 +33,6 @@
   dependencies:
     "@angular-devkit/core" "15.2.8"
     rxjs "6.6.7"
-
-"@angular-devkit/architect@0.1600.5", "@angular-devkit/architect@>=0.1600.0 < 0.1700.0":
-  version "0.1600.5"
-  resolved "https://registry.yarnpkg.com/@angular-devkit/architect/-/architect-0.1600.5.tgz#e6570f8c3bf5e98088d70607595bbdc3fdcf26f4"
-  integrity sha512-K2bfaBqWtwiuLEaWCbiVNO9jNUhA0cGT+XfQu01Tr5UO9XfNXg/2xBj17JGClJiLIUWZ6bWlaHyVVYTWQuzLxA==
-  dependencies:
-    "@angular-devkit/core" "16.0.5"
-    rxjs "7.8.1"
 
 "@angular-devkit/build-angular@^15.2.8":
   version "15.2.8"
@@ -123,78 +102,6 @@
   optionalDependencies:
     esbuild "0.17.8"
 
-"@angular-devkit/build-angular@^16.0.0":
-  version "16.0.5"
-  resolved "https://registry.yarnpkg.com/@angular-devkit/build-angular/-/build-angular-16.0.5.tgz#b9ce7026706de9c1d439917a922f70409f628a4b"
-  integrity sha512-I4B3aYv+rtvGwpwaIE2p+Uyor52UmYo93slXprhMKCW6FfYYWUScyVkufKNfdoEGO/cLRaSTo7gYkovC7bPdaA==
-  dependencies:
-    "@ampproject/remapping" "2.2.1"
-    "@angular-devkit/architect" "0.1600.5"
-    "@angular-devkit/build-webpack" "0.1600.5"
-    "@angular-devkit/core" "16.0.5"
-    "@babel/core" "7.21.4"
-    "@babel/generator" "7.21.4"
-    "@babel/helper-annotate-as-pure" "7.18.6"
-    "@babel/helper-split-export-declaration" "7.18.6"
-    "@babel/plugin-proposal-async-generator-functions" "7.20.7"
-    "@babel/plugin-transform-async-to-generator" "7.20.7"
-    "@babel/plugin-transform-runtime" "7.21.4"
-    "@babel/preset-env" "7.21.4"
-    "@babel/runtime" "7.21.0"
-    "@babel/template" "7.20.7"
-    "@discoveryjs/json-ext" "0.5.7"
-    "@ngtools/webpack" "16.0.5"
-    "@vitejs/plugin-basic-ssl" "1.0.1"
-    ansi-colors "4.1.3"
-    autoprefixer "10.4.14"
-    babel-loader "9.1.2"
-    babel-plugin-istanbul "6.1.1"
-    browserslist "4.21.5"
-    cacache "17.0.6"
-    chokidar "3.5.3"
-    copy-webpack-plugin "11.0.0"
-    critters "0.0.16"
-    css-loader "6.7.3"
-    esbuild-wasm "0.17.18"
-    glob "8.1.0"
-    https-proxy-agent "5.0.1"
-    inquirer "8.2.4"
-    jsonc-parser "3.2.0"
-    karma-source-map-support "1.4.0"
-    less "4.1.3"
-    less-loader "11.1.0"
-    license-webpack-plugin "4.0.2"
-    loader-utils "3.2.1"
-    magic-string "0.30.0"
-    mini-css-extract-plugin "2.7.5"
-    mrmime "1.0.1"
-    open "8.4.2"
-    ora "5.4.1"
-    parse5-html-rewriting-stream "7.0.0"
-    picomatch "2.3.1"
-    piscina "3.2.0"
-    postcss "8.4.23"
-    postcss-loader "7.2.4"
-    resolve-url-loader "5.0.0"
-    rxjs "7.8.1"
-    sass "1.62.1"
-    sass-loader "13.2.2"
-    semver "7.4.0"
-    source-map-loader "4.0.1"
-    source-map-support "0.5.21"
-    terser "5.17.1"
-    text-table "0.2.0"
-    tree-kill "1.2.2"
-    tslib "2.5.0"
-    vite "4.3.9"
-    webpack "5.80.0"
-    webpack-dev-middleware "6.0.2"
-    webpack-dev-server "4.13.2"
-    webpack-merge "5.8.0"
-    webpack-subresource-integrity "5.1.0"
-  optionalDependencies:
-    esbuild "0.17.18"
-
 "@angular-devkit/build-ng-packagr@^0.1002.3":
   version "0.1002.4"
   resolved "https://registry.yarnpkg.com/@angular-devkit/build-ng-packagr/-/build-ng-packagr-0.1002.4.tgz#7dc87308ffa38e355d547162d34a8d14a6bbb9b2"
@@ -210,14 +117,6 @@
   dependencies:
     "@angular-devkit/architect" "0.1502.8"
     rxjs "6.6.7"
-
-"@angular-devkit/build-webpack@0.1600.5":
-  version "0.1600.5"
-  resolved "https://registry.yarnpkg.com/@angular-devkit/build-webpack/-/build-webpack-0.1600.5.tgz#60a6ce52c483c1d8ef6bfab75eeebc3b4fadcaa9"
-  integrity sha512-jFFyPSafWUVdaNVlKdN00xLl2PdJyB7XeFQnL017oG38h6ov3RILKJnsl3bnuTsMvWjuWo17Xd6BrKLGi+b7dA==
-  dependencies:
-    "@angular-devkit/architect" "0.1600.5"
-    rxjs "7.8.1"
 
 "@angular-devkit/core@10.2.4":
   version "10.2.4"
@@ -239,17 +138,6 @@
     ajv-formats "2.1.1"
     jsonc-parser "3.2.0"
     rxjs "6.6.7"
-    source-map "0.7.4"
-
-"@angular-devkit/core@16.0.5", "@angular-devkit/core@^16.0.0":
-  version "16.0.5"
-  resolved "https://registry.yarnpkg.com/@angular-devkit/core/-/core-16.0.5.tgz#fac7882e69e3f0af52ab19f92bbf0cf7c140ede1"
-  integrity sha512-33dMesCj87zUux77cZ2BJ46YxPzeLCCmpI2fcR4Gvg4mVhBV8rdQgG7iwZDDZZNno3Lr60cVCUo9rqQj2ZXk6g==
-  dependencies:
-    ajv "8.12.0"
-    ajv-formats "2.1.1"
-    jsonc-parser "3.2.0"
-    rxjs "7.8.1"
     source-map "0.7.4"
 
 "@angular-devkit/schematics@15.2.8":
@@ -406,7 +294,7 @@
   dependencies:
     "@babel/highlight" "^7.18.6"
 
-"@babel/compat-data@^7.17.7", "@babel/compat-data@^7.20.1", "@babel/compat-data@^7.20.5", "@babel/compat-data@^7.21.4", "@babel/compat-data@^7.22.0":
+"@babel/compat-data@^7.17.7", "@babel/compat-data@^7.20.1", "@babel/compat-data@^7.20.5", "@babel/compat-data@^7.22.0":
   version "7.22.3"
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.22.3.tgz#cd502a6a0b6e37d7ad72ce7e71a7160a3ae36f7e"
   integrity sha512-aNtko9OPOwVESUFp3MZfD8Uzxl7JzSeJpd7npIoxCasU37PFbAQRpKglkaKwlHOyeJdrREpo8TW8ldrkYWwvIQ==
@@ -453,27 +341,6 @@
     json5 "^2.2.2"
     semver "^6.3.0"
 
-"@babel/core@7.21.4":
-  version "7.21.4"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.21.4.tgz#c6dc73242507b8e2a27fd13a9c1814f9fa34a659"
-  integrity sha512-qt/YV149Jman/6AfmlxJ04LMIu8bMoyl3RB91yTFrxQmgbrSvQMy7cI8Q62FHx1t8wJ8B5fu0UDoLwHAhUo1QA==
-  dependencies:
-    "@ampproject/remapping" "^2.2.0"
-    "@babel/code-frame" "^7.21.4"
-    "@babel/generator" "^7.21.4"
-    "@babel/helper-compilation-targets" "^7.21.4"
-    "@babel/helper-module-transforms" "^7.21.2"
-    "@babel/helpers" "^7.21.0"
-    "@babel/parser" "^7.21.4"
-    "@babel/template" "^7.20.7"
-    "@babel/traverse" "^7.21.4"
-    "@babel/types" "^7.21.4"
-    convert-source-map "^1.7.0"
-    debug "^4.1.0"
-    gensync "^1.0.0-beta.2"
-    json5 "^2.2.2"
-    semver "^6.3.0"
-
 "@babel/core@^7.12.3":
   version "7.22.1"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.22.1.tgz#5de51c5206f4c6f5533562838337a603c1033cfd"
@@ -504,17 +371,7 @@
     "@jridgewell/gen-mapping" "^0.3.2"
     jsesc "^2.5.1"
 
-"@babel/generator@7.21.4":
-  version "7.21.4"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.21.4.tgz#64a94b7448989f421f919d5239ef553b37bb26bc"
-  integrity sha512-NieM3pVIYW2SwGzKoqfPrQsf4xGs9M9AIG3ThppsSRmO+m7eQhmI6amajKMUeIO37wFfsvnvcxQFx6x6iqxDnA==
-  dependencies:
-    "@babel/types" "^7.21.4"
-    "@jridgewell/gen-mapping" "^0.3.2"
-    "@jridgewell/trace-mapping" "^0.3.17"
-    jsesc "^2.5.1"
-
-"@babel/generator@^7.19.3", "@babel/generator@^7.20.7", "@babel/generator@^7.21.4", "@babel/generator@^7.22.0", "@babel/generator@^7.22.3":
+"@babel/generator@^7.19.3", "@babel/generator@^7.20.7", "@babel/generator@^7.22.0", "@babel/generator@^7.22.3":
   version "7.22.3"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.22.3.tgz#0ff675d2edb93d7596c5f6728b52615cfc0df01e"
   integrity sha512-C17MW4wlk//ES/CJDL51kPNwl+qiBQyN7b9SKyVp11BLGFeSPoVaHrv+MNt8jwQFhQWowW88z1eeBx3pFz9v8A==
@@ -538,7 +395,7 @@
   dependencies:
     "@babel/types" "^7.22.3"
 
-"@babel/helper-compilation-targets@^7.17.7", "@babel/helper-compilation-targets@^7.18.9", "@babel/helper-compilation-targets@^7.19.3", "@babel/helper-compilation-targets@^7.20.0", "@babel/helper-compilation-targets@^7.20.7", "@babel/helper-compilation-targets@^7.21.4", "@babel/helper-compilation-targets@^7.22.1":
+"@babel/helper-compilation-targets@^7.17.7", "@babel/helper-compilation-targets@^7.18.9", "@babel/helper-compilation-targets@^7.19.3", "@babel/helper-compilation-targets@^7.20.0", "@babel/helper-compilation-targets@^7.20.7", "@babel/helper-compilation-targets@^7.22.1":
   version "7.22.1"
   resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.1.tgz#bfcd6b7321ffebe33290d68550e2c9d7eb7c7a58"
   integrity sha512-Rqx13UM3yVB5q0D/KwQ8+SPfX/+Rnsy1Lw1k/UwOC4KC6qrzIQoY3lYnBu5EHKBlEHHcj0M0W8ltPSkD8rqfsQ==
@@ -619,7 +476,7 @@
   dependencies:
     "@babel/types" "^7.21.4"
 
-"@babel/helper-module-transforms@^7.18.6", "@babel/helper-module-transforms@^7.19.0", "@babel/helper-module-transforms@^7.20.11", "@babel/helper-module-transforms@^7.21.2", "@babel/helper-module-transforms@^7.21.5", "@babel/helper-module-transforms@^7.22.1":
+"@babel/helper-module-transforms@^7.18.6", "@babel/helper-module-transforms@^7.19.0", "@babel/helper-module-transforms@^7.20.11", "@babel/helper-module-transforms@^7.21.5", "@babel/helper-module-transforms@^7.22.1":
   version "7.22.1"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.22.1.tgz#e0cad47fedcf3cae83c11021696376e2d5a50c63"
   integrity sha512-dxAe9E7ySDGbQdCVOY/4+UcD8M9ZFqZcZhSPsPacvCG4M+9lwtDDQfI2EoaSvmf7W/8yCBkGU0m7Pvt1ru3UZw==
@@ -713,7 +570,7 @@
     "@babel/traverse" "^7.20.5"
     "@babel/types" "^7.20.5"
 
-"@babel/helpers@^7.19.0", "@babel/helpers@^7.20.7", "@babel/helpers@^7.21.0", "@babel/helpers@^7.22.0":
+"@babel/helpers@^7.19.0", "@babel/helpers@^7.20.7", "@babel/helpers@^7.22.0":
   version "7.22.3"
   resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.22.3.tgz#53b74351da9684ea2f694bf0877998da26dd830e"
   integrity sha512-jBJ7jWblbgr7r6wYZHMdIqKc73ycaTcCaWRq4/2LpuPHcx7xMlZvpGQkOYc9HeSjn6rcx15CPlgVcBtZ4WZJ2w==
@@ -731,7 +588,7 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.14.7", "@babel/parser@^7.19.3", "@babel/parser@^7.20.7", "@babel/parser@^7.21.4", "@babel/parser@^7.21.9", "@babel/parser@^7.22.0", "@babel/parser@^7.22.4":
+"@babel/parser@^7.14.7", "@babel/parser@^7.19.3", "@babel/parser@^7.20.7", "@babel/parser@^7.21.9", "@babel/parser@^7.22.0", "@babel/parser@^7.22.4":
   version "7.22.4"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.22.4.tgz#a770e98fd785c231af9d93f6459d36770993fb32"
   integrity sha512-VLLsx06XkEYqBtE5YGPwfSGwfrjnyPP5oiGty3S8pQLFDFLaS8VwWSIxkTXpcvr5zeYLE6+MBNl2npl/YnfofA==
@@ -743,7 +600,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.18.6"
 
-"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@^7.18.9", "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@^7.20.7":
+"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@^7.18.9":
   version "7.22.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.22.3.tgz#a75be1365c0c3188c51399a662168c1c98108659"
   integrity sha512-6r4yRwEnorYByILoDRnEqxtojYKuiIv9FojW2E8GUKo9eWBwbKcd9IiZOZpdyXc64RmyGGyPu3/uAcrz/dq2kQ==
@@ -752,7 +609,7 @@
     "@babel/helper-skip-transparent-expression-wrappers" "^7.20.0"
     "@babel/plugin-transform-optional-chaining" "^7.22.3"
 
-"@babel/plugin-proposal-async-generator-functions@7.20.7", "@babel/plugin-proposal-async-generator-functions@^7.20.1", "@babel/plugin-proposal-async-generator-functions@^7.20.7":
+"@babel/plugin-proposal-async-generator-functions@7.20.7", "@babel/plugin-proposal-async-generator-functions@^7.20.1":
   version "7.20.7"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.20.7.tgz#bfb7276d2d573cb67ba379984a2334e262ba5326"
   integrity sha512-xMbiLsn/8RK7Wq7VeVytytS2L6qE69bXPB10YCmMdDZbKF4okCqY74pI/jJQ/8U0b/F6NrT2+14b8/P9/3AMGA==
@@ -770,7 +627,7 @@
     "@babel/helper-create-class-features-plugin" "^7.18.6"
     "@babel/helper-plugin-utils" "^7.18.6"
 
-"@babel/plugin-proposal-class-static-block@^7.18.6", "@babel/plugin-proposal-class-static-block@^7.21.0":
+"@babel/plugin-proposal-class-static-block@^7.18.6":
   version "7.21.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-class-static-block/-/plugin-proposal-class-static-block-7.21.0.tgz#77bdd66fb7b605f3a61302d224bdfacf5547977d"
   integrity sha512-XP5G9MWNUskFuP30IfFSEFB0Z6HzLIUcjYM4bYOPHXl7eiJ9HFv8tWj6TXTN5QODiEhDZAeI4hLok2iHFFV4hw==
@@ -803,7 +660,7 @@
     "@babel/helper-plugin-utils" "^7.18.6"
     "@babel/plugin-syntax-json-strings" "^7.8.3"
 
-"@babel/plugin-proposal-logical-assignment-operators@^7.18.9", "@babel/plugin-proposal-logical-assignment-operators@^7.20.7":
+"@babel/plugin-proposal-logical-assignment-operators@^7.18.9":
   version "7.20.7"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-logical-assignment-operators/-/plugin-proposal-logical-assignment-operators-7.20.7.tgz#dfbcaa8f7b4d37b51e8bfb46d94a5aea2bb89d83"
   integrity sha512-y7C7cZgpMIjWlKE5T7eJwp+tnRYM89HmRvWM5EQuB5BoHEONjmQ8lSNmBUwOyy/GFRsohJED51YBF79hE1djug==
@@ -827,7 +684,7 @@
     "@babel/helper-plugin-utils" "^7.18.6"
     "@babel/plugin-syntax-numeric-separator" "^7.10.4"
 
-"@babel/plugin-proposal-object-rest-spread@^7.20.2", "@babel/plugin-proposal-object-rest-spread@^7.20.7":
+"@babel/plugin-proposal-object-rest-spread@^7.20.2":
   version "7.20.7"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.20.7.tgz#aa662940ef425779c75534a5c41e9d936edc390a"
   integrity sha512-d2S98yCiLxDVmBmE8UjGcfPvNEUbA1U5q5WxaWFUGRzJSVAZqm5W6MbPct0jxnegUZ0niLeNX+IOzEs7wYg9Dg==
@@ -846,7 +703,7 @@
     "@babel/helper-plugin-utils" "^7.18.6"
     "@babel/plugin-syntax-optional-catch-binding" "^7.8.3"
 
-"@babel/plugin-proposal-optional-chaining@^7.18.9", "@babel/plugin-proposal-optional-chaining@^7.21.0":
+"@babel/plugin-proposal-optional-chaining@^7.18.9":
   version "7.21.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.21.0.tgz#886f5c8978deb7d30f678b2e24346b287234d3ea"
   integrity sha512-p4zeefM72gpmEe2fkUr/OnOXpWEf8nAgk7ZYVqqfFiyIG7oFfVZcCrU64hWn5xp4tQ9LkV4bTIa5rD0KANpKNA==
@@ -863,7 +720,7 @@
     "@babel/helper-create-class-features-plugin" "^7.18.6"
     "@babel/helper-plugin-utils" "^7.18.6"
 
-"@babel/plugin-proposal-private-property-in-object@^7.18.6", "@babel/plugin-proposal-private-property-in-object@^7.21.0":
+"@babel/plugin-proposal-private-property-in-object@^7.18.6":
   version "7.21.11"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.11.tgz#69d597086b6760c4126525cfa154f34631ff272c"
   integrity sha512-0QZ8qP/3RLDVBwBFoWAwCtgcDZJVwA5LUJRZU8x2YFfKNuFq161wK3cuGrALu5yiPu+vzwTAg/sMWVNeWeNyaw==
@@ -986,14 +843,14 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
 
-"@babel/plugin-transform-arrow-functions@^7.18.6", "@babel/plugin-transform-arrow-functions@^7.20.7":
+"@babel/plugin-transform-arrow-functions@^7.18.6":
   version "7.21.5"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.21.5.tgz#9bb42a53de447936a57ba256fbf537fc312b6929"
   integrity sha512-wb1mhwGOCaXHDTcsRYMKF9e5bbMgqwxtqa2Y1ifH96dXJPwbuLX9qHy3clhrxVqgMz7nyNXs8VkxdH8UBcjKqA==
   dependencies:
     "@babel/helper-plugin-utils" "^7.21.5"
 
-"@babel/plugin-transform-async-to-generator@7.20.7", "@babel/plugin-transform-async-to-generator@^7.18.6", "@babel/plugin-transform-async-to-generator@^7.20.7":
+"@babel/plugin-transform-async-to-generator@7.20.7", "@babel/plugin-transform-async-to-generator@^7.18.6":
   version "7.20.7"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.20.7.tgz#dfee18623c8cb31deb796aa3ca84dda9cea94354"
   integrity sha512-Uo5gwHPT9vgnSXQxqGtpdufUiWp96gk7yiP4Mp5bm1QMkEmLXBO7PAGYbKoJ6DhAwiNkcHFBol/x5zZZkL/t0Q==
@@ -1009,14 +866,14 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.18.6"
 
-"@babel/plugin-transform-block-scoping@^7.20.2", "@babel/plugin-transform-block-scoping@^7.21.0":
+"@babel/plugin-transform-block-scoping@^7.20.2":
   version "7.21.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.21.0.tgz#e737b91037e5186ee16b76e7ae093358a5634f02"
   integrity sha512-Mdrbunoh9SxwFZapeHVrwFmri16+oYotcZysSzhNIVDwIAb1UV+kvnxULSYq9J3/q5MDG+4X6w8QVgD1zhBXNQ==
   dependencies:
     "@babel/helper-plugin-utils" "^7.20.2"
 
-"@babel/plugin-transform-classes@^7.20.2", "@babel/plugin-transform-classes@^7.21.0":
+"@babel/plugin-transform-classes@^7.20.2":
   version "7.21.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-classes/-/plugin-transform-classes-7.21.0.tgz#f469d0b07a4c5a7dbb21afad9e27e57b47031665"
   integrity sha512-RZhbYTCEUAe6ntPehC4hlslPWosNHDox+vAs4On/mCLRLfoDVHf6hVEd7kuxr1RnHwJmxFfUM3cZiZRmPxJPXQ==
@@ -1031,7 +888,7 @@
     "@babel/helper-split-export-declaration" "^7.18.6"
     globals "^11.1.0"
 
-"@babel/plugin-transform-computed-properties@^7.18.9", "@babel/plugin-transform-computed-properties@^7.20.7":
+"@babel/plugin-transform-computed-properties@^7.18.9":
   version "7.21.5"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.21.5.tgz#3a2d8bb771cd2ef1cd736435f6552fe502e11b44"
   integrity sha512-TR653Ki3pAwxBxUe8srfF3e4Pe3FTA46uaNHYyQwIoM4oWKSoOZiDNyHJ0oIoDIUPSRQbQG7jzgVBX3FPVne1Q==
@@ -1039,7 +896,7 @@
     "@babel/helper-plugin-utils" "^7.21.5"
     "@babel/template" "^7.20.7"
 
-"@babel/plugin-transform-destructuring@^7.20.2", "@babel/plugin-transform-destructuring@^7.21.3":
+"@babel/plugin-transform-destructuring@^7.20.2":
   version "7.21.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.21.3.tgz#73b46d0fd11cd6ef57dea8a381b1215f4959d401"
   integrity sha512-bp6hwMFzuiE4HqYEyoGJ/V2LeIWn+hLVKc4pnj++E5XQptwhtcGmSayM029d/j2X1bPKGTlsyPwAubuU22KhMA==
@@ -1069,7 +926,7 @@
     "@babel/helper-builder-binary-assignment-operator-visitor" "^7.18.6"
     "@babel/helper-plugin-utils" "^7.18.6"
 
-"@babel/plugin-transform-for-of@^7.18.8", "@babel/plugin-transform-for-of@^7.21.0":
+"@babel/plugin-transform-for-of@^7.18.8":
   version "7.21.5"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.21.5.tgz#e890032b535f5a2e237a18535f56a9fdaa7b83fc"
   integrity sha512-nYWpjKW/7j/I/mZkGVgHJXh4bA1sfdFnJoOXwJuj4m3Q2EraO/8ZyrkCau9P5tbHQk01RMSt6KYLCsW7730SXQ==
@@ -1099,7 +956,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.18.6"
 
-"@babel/plugin-transform-modules-amd@^7.19.6", "@babel/plugin-transform-modules-amd@^7.20.11":
+"@babel/plugin-transform-modules-amd@^7.19.6":
   version "7.20.11"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.20.11.tgz#3daccca8e4cc309f03c3a0c4b41dc4b26f55214a"
   integrity sha512-NuzCt5IIYOW0O30UvqktzHYR2ud5bOWbY0yaxWZ6G+aFzOMJvrs5YHNikrbdaT15+KNO31nPOy5Fim3ku6Zb5g==
@@ -1107,7 +964,7 @@
     "@babel/helper-module-transforms" "^7.20.11"
     "@babel/helper-plugin-utils" "^7.20.2"
 
-"@babel/plugin-transform-modules-commonjs@^7.19.6", "@babel/plugin-transform-modules-commonjs@^7.21.2":
+"@babel/plugin-transform-modules-commonjs@^7.19.6":
   version "7.21.5"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.21.5.tgz#d69fb947eed51af91de82e4708f676864e5e47bc"
   integrity sha512-OVryBEgKUbtqMoB7eG2rs6UFexJi6Zj6FDXx+esBLPTCxCNxAY9o+8Di7IsUGJ+AVhp5ncK0fxWUBd0/1gPhrQ==
@@ -1116,7 +973,7 @@
     "@babel/helper-plugin-utils" "^7.21.5"
     "@babel/helper-simple-access" "^7.21.5"
 
-"@babel/plugin-transform-modules-systemjs@^7.19.6", "@babel/plugin-transform-modules-systemjs@^7.20.11":
+"@babel/plugin-transform-modules-systemjs@^7.19.6":
   version "7.22.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.22.3.tgz#cc507e03e88d87b016feaeb5dae941e6ef50d91e"
   integrity sha512-V21W3bKLxO3ZjcBJZ8biSvo5gQ85uIXW2vJfh7JSWf/4SLUSr1tOoHX3ruN4+Oqa2m+BKfsxTR1I+PsvkIWvNw==
@@ -1134,7 +991,7 @@
     "@babel/helper-module-transforms" "^7.18.6"
     "@babel/helper-plugin-utils" "^7.18.6"
 
-"@babel/plugin-transform-named-capturing-groups-regex@^7.19.1", "@babel/plugin-transform-named-capturing-groups-regex@^7.20.5":
+"@babel/plugin-transform-named-capturing-groups-regex@^7.19.1":
   version "7.22.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.22.3.tgz#db6fb77e6b3b53ec3b8d370246f0b7cf67d35ab4"
   integrity sha512-c6HrD/LpUdNNJsISQZpds3TXvfYIAbo+efE9aWmY/PmSRD0agrJ9cPMt4BmArwUQ7ZymEWTFjTyp+yReLJZh0Q==
@@ -1166,7 +1023,7 @@
     "@babel/helper-skip-transparent-expression-wrappers" "^7.20.0"
     "@babel/plugin-syntax-optional-chaining" "^7.8.3"
 
-"@babel/plugin-transform-parameters@^7.20.1", "@babel/plugin-transform-parameters@^7.20.7", "@babel/plugin-transform-parameters@^7.21.3":
+"@babel/plugin-transform-parameters@^7.20.1", "@babel/plugin-transform-parameters@^7.20.7":
   version "7.22.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.22.3.tgz#24477acfd2fd2bc901df906c9bf17fbcfeee900d"
   integrity sha512-x7QHQJHPuD9VmfpzboyGJ5aHEr9r7DsAsdxdhJiTB3J3j8dyl+NFZ+rX5Q2RWFDCs61c06qBfS4ys2QYn8UkMw==
@@ -1180,7 +1037,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.18.6"
 
-"@babel/plugin-transform-regenerator@^7.18.6", "@babel/plugin-transform-regenerator@^7.20.5":
+"@babel/plugin-transform-regenerator@^7.18.6":
   version "7.21.5"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.21.5.tgz#576c62f9923f94bcb1c855adc53561fd7913724e"
   integrity sha512-ZoYBKDb6LyMi5yCsByQ5jmXsHAQDDYeexT1Szvlmui+lADvfSecr5Dxd/PkrTC3pAD182Fcju1VQkB4oCp9M+w==
@@ -1207,18 +1064,6 @@
     babel-plugin-polyfill-regenerator "^0.4.1"
     semver "^6.3.0"
 
-"@babel/plugin-transform-runtime@7.21.4":
-  version "7.21.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.21.4.tgz#2e1da21ca597a7d01fc96b699b21d8d2023191aa"
-  integrity sha512-1J4dhrw1h1PqnNNpzwxQ2UBymJUF8KuPjAAnlLwZcGhHAIqUigFW7cdK6GHoB64ubY4qXQNYknoUeks4Wz7CUA==
-  dependencies:
-    "@babel/helper-module-imports" "^7.21.4"
-    "@babel/helper-plugin-utils" "^7.20.2"
-    babel-plugin-polyfill-corejs2 "^0.3.3"
-    babel-plugin-polyfill-corejs3 "^0.6.0"
-    babel-plugin-polyfill-regenerator "^0.4.1"
-    semver "^6.3.0"
-
 "@babel/plugin-transform-shorthand-properties@^7.18.6":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.18.6.tgz#6d6df7983d67b195289be24909e3f12a8f664dc9"
@@ -1226,7 +1071,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.18.6"
 
-"@babel/plugin-transform-spread@^7.19.0", "@babel/plugin-transform-spread@^7.20.7":
+"@babel/plugin-transform-spread@^7.19.0":
   version "7.20.7"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-spread/-/plugin-transform-spread-7.20.7.tgz#c2d83e0b99d3bf83e07b11995ee24bf7ca09401e"
   integrity sha512-ewBbHQ+1U/VnH1fxltbJqDeWBU1oNLG8Dj11uIv3xVf7nrQu0bPGe5Rf716r7K5Qz+SqtAOVswoVunoiBtGhxw==
@@ -1351,87 +1196,6 @@
     core-js-compat "^3.25.1"
     semver "^6.3.0"
 
-"@babel/preset-env@7.21.4":
-  version "7.21.4"
-  resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.21.4.tgz#a952482e634a8dd8271a3fe5459a16eb10739c58"
-  integrity sha512-2W57zHs2yDLm6GD5ZpvNn71lZ0B/iypSdIeq25OurDKji6AdzV07qp4s3n1/x5BqtiGaTrPN3nerlSCaC5qNTw==
-  dependencies:
-    "@babel/compat-data" "^7.21.4"
-    "@babel/helper-compilation-targets" "^7.21.4"
-    "@babel/helper-plugin-utils" "^7.20.2"
-    "@babel/helper-validator-option" "^7.21.0"
-    "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression" "^7.18.6"
-    "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining" "^7.20.7"
-    "@babel/plugin-proposal-async-generator-functions" "^7.20.7"
-    "@babel/plugin-proposal-class-properties" "^7.18.6"
-    "@babel/plugin-proposal-class-static-block" "^7.21.0"
-    "@babel/plugin-proposal-dynamic-import" "^7.18.6"
-    "@babel/plugin-proposal-export-namespace-from" "^7.18.9"
-    "@babel/plugin-proposal-json-strings" "^7.18.6"
-    "@babel/plugin-proposal-logical-assignment-operators" "^7.20.7"
-    "@babel/plugin-proposal-nullish-coalescing-operator" "^7.18.6"
-    "@babel/plugin-proposal-numeric-separator" "^7.18.6"
-    "@babel/plugin-proposal-object-rest-spread" "^7.20.7"
-    "@babel/plugin-proposal-optional-catch-binding" "^7.18.6"
-    "@babel/plugin-proposal-optional-chaining" "^7.21.0"
-    "@babel/plugin-proposal-private-methods" "^7.18.6"
-    "@babel/plugin-proposal-private-property-in-object" "^7.21.0"
-    "@babel/plugin-proposal-unicode-property-regex" "^7.18.6"
-    "@babel/plugin-syntax-async-generators" "^7.8.4"
-    "@babel/plugin-syntax-class-properties" "^7.12.13"
-    "@babel/plugin-syntax-class-static-block" "^7.14.5"
-    "@babel/plugin-syntax-dynamic-import" "^7.8.3"
-    "@babel/plugin-syntax-export-namespace-from" "^7.8.3"
-    "@babel/plugin-syntax-import-assertions" "^7.20.0"
-    "@babel/plugin-syntax-json-strings" "^7.8.3"
-    "@babel/plugin-syntax-logical-assignment-operators" "^7.10.4"
-    "@babel/plugin-syntax-nullish-coalescing-operator" "^7.8.3"
-    "@babel/plugin-syntax-numeric-separator" "^7.10.4"
-    "@babel/plugin-syntax-object-rest-spread" "^7.8.3"
-    "@babel/plugin-syntax-optional-catch-binding" "^7.8.3"
-    "@babel/plugin-syntax-optional-chaining" "^7.8.3"
-    "@babel/plugin-syntax-private-property-in-object" "^7.14.5"
-    "@babel/plugin-syntax-top-level-await" "^7.14.5"
-    "@babel/plugin-transform-arrow-functions" "^7.20.7"
-    "@babel/plugin-transform-async-to-generator" "^7.20.7"
-    "@babel/plugin-transform-block-scoped-functions" "^7.18.6"
-    "@babel/plugin-transform-block-scoping" "^7.21.0"
-    "@babel/plugin-transform-classes" "^7.21.0"
-    "@babel/plugin-transform-computed-properties" "^7.20.7"
-    "@babel/plugin-transform-destructuring" "^7.21.3"
-    "@babel/plugin-transform-dotall-regex" "^7.18.6"
-    "@babel/plugin-transform-duplicate-keys" "^7.18.9"
-    "@babel/plugin-transform-exponentiation-operator" "^7.18.6"
-    "@babel/plugin-transform-for-of" "^7.21.0"
-    "@babel/plugin-transform-function-name" "^7.18.9"
-    "@babel/plugin-transform-literals" "^7.18.9"
-    "@babel/plugin-transform-member-expression-literals" "^7.18.6"
-    "@babel/plugin-transform-modules-amd" "^7.20.11"
-    "@babel/plugin-transform-modules-commonjs" "^7.21.2"
-    "@babel/plugin-transform-modules-systemjs" "^7.20.11"
-    "@babel/plugin-transform-modules-umd" "^7.18.6"
-    "@babel/plugin-transform-named-capturing-groups-regex" "^7.20.5"
-    "@babel/plugin-transform-new-target" "^7.18.6"
-    "@babel/plugin-transform-object-super" "^7.18.6"
-    "@babel/plugin-transform-parameters" "^7.21.3"
-    "@babel/plugin-transform-property-literals" "^7.18.6"
-    "@babel/plugin-transform-regenerator" "^7.20.5"
-    "@babel/plugin-transform-reserved-words" "^7.18.6"
-    "@babel/plugin-transform-shorthand-properties" "^7.18.6"
-    "@babel/plugin-transform-spread" "^7.20.7"
-    "@babel/plugin-transform-sticky-regex" "^7.18.6"
-    "@babel/plugin-transform-template-literals" "^7.18.9"
-    "@babel/plugin-transform-typeof-symbol" "^7.18.9"
-    "@babel/plugin-transform-unicode-escapes" "^7.18.10"
-    "@babel/plugin-transform-unicode-regex" "^7.18.6"
-    "@babel/preset-modules" "^0.1.5"
-    "@babel/types" "^7.21.4"
-    babel-plugin-polyfill-corejs2 "^0.3.3"
-    babel-plugin-polyfill-corejs3 "^0.6.0"
-    babel-plugin-polyfill-regenerator "^0.4.1"
-    core-js-compat "^3.25.1"
-    semver "^6.3.0"
-
 "@babel/preset-modules@^0.1.5":
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/@babel/preset-modules/-/preset-modules-0.1.5.tgz#ef939d6e7f268827e1841638dc6ff95515e115d9"
@@ -1452,13 +1216,6 @@
   version "7.20.13"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.20.13.tgz#7055ab8a7cff2b8f6058bf6ae45ff84ad2aded4b"
   integrity sha512-gt3PKXs0DBoL9xCvOIIZ2NEqAGZqHjAnmVbfQtB620V0uReIQutpel14KcneZuer7UioY8ALKZ7iocavvzTNFA==
-  dependencies:
-    regenerator-runtime "^0.13.11"
-
-"@babel/runtime@7.21.0":
-  version "7.21.0"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.21.0.tgz#5b55c9d394e5fcf304909a8b00c07dc217b56673"
-  integrity sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==
   dependencies:
     regenerator-runtime "^0.13.11"
 
@@ -1494,7 +1251,7 @@
     "@babel/parser" "^7.21.9"
     "@babel/types" "^7.21.5"
 
-"@babel/traverse@^7.19.3", "@babel/traverse@^7.20.12", "@babel/traverse@^7.20.5", "@babel/traverse@^7.21.4", "@babel/traverse@^7.22.1":
+"@babel/traverse@^7.19.3", "@babel/traverse@^7.20.12", "@babel/traverse@^7.20.5", "@babel/traverse@^7.22.1":
   version "7.22.4"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.22.4.tgz#c3cf96c5c290bd13b55e29d025274057727664c0"
   integrity sha512-Tn1pDsjIcI+JcLKq1AVlZEr4226gpuAQTsLMorsYg9tuS/kG7nuwwJ4AB8jfQuEgb/COBwR/DqJxmoiYFu5/rQ==
@@ -1536,330 +1293,110 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
   integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
 
-"@esbuild/android-arm64@0.17.18":
-  version "0.17.18"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.17.18.tgz#4aa8d8afcffb4458736ca9b32baa97d7cb5861ea"
-  integrity sha512-/iq0aK0eeHgSC3z55ucMAHO05OIqmQehiGay8eP5l/5l+iEr4EIbh4/MI8xD9qRFjqzgkc0JkX0LculNC9mXBw==
-
-"@esbuild/android-arm64@0.17.19":
-  version "0.17.19"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.17.19.tgz#bafb75234a5d3d1b690e7c2956a599345e84a2fd"
-  integrity sha512-KBMWvEZooR7+kzY0BtbTQn0OAYY7CsiydT63pVEaPtVYF0hXbUaOyZog37DKxK7NF3XacBJOpYT4adIJh+avxA==
-
 "@esbuild/android-arm64@0.17.8":
   version "0.17.8"
   resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.17.8.tgz#b3d5b65a3b2e073a6c7ee36b1f3c30c8f000315b"
   integrity sha512-oa/N5j6v1svZQs7EIRPqR8f+Bf8g6HBDjD/xHC02radE/NjKHK7oQmtmLxPs1iVwYyvE+Kolo6lbpfEQ9xnhxQ==
-
-"@esbuild/android-arm@0.17.18":
-  version "0.17.18"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.17.18.tgz#74a7e95af4ee212ebc9db9baa87c06a594f2a427"
-  integrity sha512-EmwL+vUBZJ7mhFCs5lA4ZimpUH3WMAoqvOIYhVQwdIgSpHC8ImHdsRyhHAVxpDYUSm0lWvd63z0XH1IlImS2Qw==
-
-"@esbuild/android-arm@0.17.19":
-  version "0.17.19"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.17.19.tgz#5898f7832c2298bc7d0ab53701c57beb74d78b4d"
-  integrity sha512-rIKddzqhmav7MSmoFCmDIb6e2W57geRsM94gV2l38fzhXMwq7hZoClug9USI2pFRGL06f4IOPHHpFNOkWieR8A==
 
 "@esbuild/android-arm@0.17.8":
   version "0.17.8"
   resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.17.8.tgz#c41e496af541e175369d48164d0cf01a5f656cf6"
   integrity sha512-0/rb91GYKhrtbeglJXOhAv9RuYimgI8h623TplY2X+vA4EXnk3Zj1fXZreJ0J3OJJu1bwmb0W7g+2cT/d8/l/w==
 
-"@esbuild/android-x64@0.17.18":
-  version "0.17.18"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.17.18.tgz#1dcd13f201997c9fe0b204189d3a0da4eb4eb9b6"
-  integrity sha512-x+0efYNBF3NPW2Xc5bFOSFW7tTXdAcpfEg2nXmxegm4mJuVeS+i109m/7HMiOQ6M12aVGGFlqJX3RhNdYM2lWg==
-
-"@esbuild/android-x64@0.17.19":
-  version "0.17.19"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.17.19.tgz#658368ef92067866d95fb268719f98f363d13ae1"
-  integrity sha512-uUTTc4xGNDT7YSArp/zbtmbhO0uEEK9/ETW29Wk1thYUJBz3IVnvgEiEwEa9IeLyvnpKrWK64Utw2bgUmDveww==
-
 "@esbuild/android-x64@0.17.8":
   version "0.17.8"
   resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.17.8.tgz#080fa67c29be77f5a3ca5ee4cc78d5bf927e3a3b"
   integrity sha512-bTliMLqD7pTOoPg4zZkXqCDuzIUguEWLpeqkNfC41ODBHwoUgZ2w5JBeYimv4oP6TDVocoYmEhZrCLQTrH89bg==
-
-"@esbuild/darwin-arm64@0.17.18":
-  version "0.17.18"
-  resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.17.18.tgz#444f3b961d4da7a89eb9bd35cfa4415141537c2a"
-  integrity sha512-6tY+djEAdF48M1ONWnQb1C+6LiXrKjmqjzPNPWXhu/GzOHTHX2nh8Mo2ZAmBFg0kIodHhciEgUBtcYCAIjGbjQ==
-
-"@esbuild/darwin-arm64@0.17.19":
-  version "0.17.19"
-  resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.17.19.tgz#584c34c5991b95d4d48d333300b1a4e2ff7be276"
-  integrity sha512-80wEoCfF/hFKM6WE1FyBHc9SfUblloAWx6FJkFWTWiCoht9Mc0ARGEM47e67W9rI09YoUxJL68WHfDRYEAvOhg==
 
 "@esbuild/darwin-arm64@0.17.8":
   version "0.17.8"
   resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.17.8.tgz#053622bf9a82f43d5c075b7818e02618f7b4a397"
   integrity sha512-ghAbV3ia2zybEefXRRm7+lx8J/rnupZT0gp9CaGy/3iolEXkJ6LYRq4IpQVI9zR97ID80KJVoUlo3LSeA/sMAg==
 
-"@esbuild/darwin-x64@0.17.18":
-  version "0.17.18"
-  resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.17.18.tgz#a6da308d0ac8a498c54d62e0b2bfb7119b22d315"
-  integrity sha512-Qq84ykvLvya3dO49wVC9FFCNUfSrQJLbxhoQk/TE1r6MjHo3sFF2tlJCwMjhkBVq3/ahUisj7+EpRSz0/+8+9A==
-
-"@esbuild/darwin-x64@0.17.19":
-  version "0.17.19"
-  resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.17.19.tgz#7751d236dfe6ce136cce343dce69f52d76b7f6cb"
-  integrity sha512-IJM4JJsLhRYr9xdtLytPLSH9k/oxR3boaUIYiHkAawtwNOXKE8KoU8tMvryogdcT8AU+Bflmh81Xn6Q0vTZbQw==
-
 "@esbuild/darwin-x64@0.17.8":
   version "0.17.8"
   resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.17.8.tgz#8a1aadb358d537d8efad817bb1a5bff91b84734b"
   integrity sha512-n5WOpyvZ9TIdv2V1K3/iIkkJeKmUpKaCTdun9buhGRWfH//osmUjlv4Z5mmWdPWind/VGcVxTHtLfLCOohsOXw==
-
-"@esbuild/freebsd-arm64@0.17.18":
-  version "0.17.18"
-  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.18.tgz#b83122bb468889399d0d63475d5aea8d6829c2c2"
-  integrity sha512-fw/ZfxfAzuHfaQeMDhbzxp9mc+mHn1Y94VDHFHjGvt2Uxl10mT4CDavHm+/L9KG441t1QdABqkVYwakMUeyLRA==
-
-"@esbuild/freebsd-arm64@0.17.19":
-  version "0.17.19"
-  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.19.tgz#cacd171665dd1d500f45c167d50c6b7e539d5fd2"
-  integrity sha512-pBwbc7DufluUeGdjSU5Si+P3SoMF5DQ/F/UmTSb8HXO80ZEAJmrykPyzo1IfNbAoaqw48YRpv8shwd1NoI0jcQ==
 
 "@esbuild/freebsd-arm64@0.17.8":
   version "0.17.8"
   resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.8.tgz#e6738d0081ba0721a5c6c674e84c6e7fcea61989"
   integrity sha512-a/SATTaOhPIPFWvHZDoZYgxaZRVHn0/LX1fHLGfZ6C13JqFUZ3K6SMD6/HCtwOQ8HnsNaEeokdiDSFLuizqv5A==
 
-"@esbuild/freebsd-x64@0.17.18":
-  version "0.17.18"
-  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.17.18.tgz#af59e0e03fcf7f221b34d4c5ab14094862c9c864"
-  integrity sha512-FQFbRtTaEi8ZBi/A6kxOC0V0E9B/97vPdYjY9NdawyLd4Qk5VD5g2pbWN2VR1c0xhzcJm74HWpObPszWC+qTew==
-
-"@esbuild/freebsd-x64@0.17.19":
-  version "0.17.19"
-  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.17.19.tgz#0769456eee2a08b8d925d7c00b79e861cb3162e4"
-  integrity sha512-4lu+n8Wk0XlajEhbEffdy2xy53dpR06SlzvhGByyg36qJw6Kpfk7cp45DR/62aPH9mtJRmIyrXAS5UWBrJT6TQ==
-
 "@esbuild/freebsd-x64@0.17.8":
   version "0.17.8"
   resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.17.8.tgz#1855e562f2b730f4483f6e94086e9e2597feb4c3"
   integrity sha512-xpFJb08dfXr5+rZc4E+ooZmayBW6R3q59daCpKZ/cDU96/kvDM+vkYzNeTJCGd8rtO6fHWMq5Rcv/1cY6p6/0Q==
-
-"@esbuild/linux-arm64@0.17.18":
-  version "0.17.18"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.17.18.tgz#8551d72ba540c5bce4bab274a81c14ed01eafdcf"
-  integrity sha512-R7pZvQZFOY2sxUG8P6A21eq6q+eBv7JPQYIybHVf1XkQYC+lT7nDBdC7wWKTrbvMXKRaGudp/dzZCwL/863mZQ==
-
-"@esbuild/linux-arm64@0.17.19":
-  version "0.17.19"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.17.19.tgz#38e162ecb723862c6be1c27d6389f48960b68edb"
-  integrity sha512-ct1Tg3WGwd3P+oZYqic+YZF4snNl2bsnMKRkb3ozHmnM0dGWuxcPTTntAF6bOP0Sp4x0PjSF+4uHQ1xvxfRKqg==
 
 "@esbuild/linux-arm64@0.17.8":
   version "0.17.8"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.17.8.tgz#481da38952721a3fdb77c17a36ceaacc4270b5c5"
   integrity sha512-v3iwDQuDljLTxpsqQDl3fl/yihjPAyOguxuloON9kFHYwopeJEf1BkDXODzYyXEI19gisEsQlG1bM65YqKSIww==
 
-"@esbuild/linux-arm@0.17.18":
-  version "0.17.18"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.17.18.tgz#e09e76e526df4f665d4d2720d28ff87d15cdf639"
-  integrity sha512-jW+UCM40LzHcouIaqv3e/oRs0JM76JfhHjCavPxMUti7VAPh8CaGSlS7cmyrdpzSk7A+8f0hiedHqr/LMnfijg==
-
-"@esbuild/linux-arm@0.17.19":
-  version "0.17.19"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.17.19.tgz#1a2cd399c50040184a805174a6d89097d9d1559a"
-  integrity sha512-cdmT3KxjlOQ/gZ2cjfrQOtmhG4HJs6hhvm3mWSRDPtZ/lP5oe8FWceS10JaSJC13GBd4eH/haHnqf7hhGNLerA==
-
 "@esbuild/linux-arm@0.17.8":
   version "0.17.8"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.17.8.tgz#18127072b270bb6321c6d11be20bfd30e0d6ad17"
   integrity sha512-6Ij8gfuGszcEwZpi5jQIJCVIACLS8Tz2chnEBfYjlmMzVsfqBP1iGmHQPp7JSnZg5xxK9tjCc+pJ2WtAmPRFVA==
-
-"@esbuild/linux-ia32@0.17.18":
-  version "0.17.18"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.17.18.tgz#47878860ce4fe73a36fd8627f5647bcbbef38ba4"
-  integrity sha512-ygIMc3I7wxgXIxk6j3V00VlABIjq260i967Cp9BNAk5pOOpIXmd1RFQJQX9Io7KRsthDrQYrtcx7QCof4o3ZoQ==
-
-"@esbuild/linux-ia32@0.17.19":
-  version "0.17.19"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.17.19.tgz#e28c25266b036ce1cabca3c30155222841dc035a"
-  integrity sha512-w4IRhSy1VbsNxHRQpeGCHEmibqdTUx61Vc38APcsRbuVgK0OPEnQ0YD39Brymn96mOx48Y2laBQGqgZ0j9w6SQ==
 
 "@esbuild/linux-ia32@0.17.8":
   version "0.17.8"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.17.8.tgz#ee400af7b3bc69e8ca2e593ca35156ffb9abd54f"
   integrity sha512-8svILYKhE5XetuFk/B6raFYIyIqydQi+GngEXJgdPdI7OMKUbSd7uzR02wSY4kb53xBrClLkhH4Xs8P61Q2BaA==
 
-"@esbuild/linux-loong64@0.17.18":
-  version "0.17.18"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.17.18.tgz#3f8fbf5267556fc387d20b2e708ce115de5c967a"
-  integrity sha512-bvPG+MyFs5ZlwYclCG1D744oHk1Pv7j8psF5TfYx7otCVmcJsEXgFEhQkbhNW8otDHL1a2KDINW20cfCgnzgMQ==
-
-"@esbuild/linux-loong64@0.17.19":
-  version "0.17.19"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.17.19.tgz#0f887b8bb3f90658d1a0117283e55dbd4c9dcf72"
-  integrity sha512-2iAngUbBPMq439a+z//gE+9WBldoMp1s5GWsUSgqHLzLJ9WoZLZhpwWuym0u0u/4XmZ3gpHmzV84PonE+9IIdQ==
-
 "@esbuild/linux-loong64@0.17.8":
   version "0.17.8"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.17.8.tgz#8c509d8a454693d39824b83b3f66c400872fce82"
   integrity sha512-B6FyMeRJeV0NpyEOYlm5qtQfxbdlgmiGdD+QsipzKfFky0K5HW5Td6dyK3L3ypu1eY4kOmo7wW0o94SBqlqBSA==
-
-"@esbuild/linux-mips64el@0.17.18":
-  version "0.17.18"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.17.18.tgz#9d896d8f3c75f6c226cbeb840127462e37738226"
-  integrity sha512-oVqckATOAGuiUOa6wr8TXaVPSa+6IwVJrGidmNZS1cZVx0HqkTMkqFGD2HIx9H1RvOwFeWYdaYbdY6B89KUMxA==
-
-"@esbuild/linux-mips64el@0.17.19":
-  version "0.17.19"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.17.19.tgz#f5d2a0b8047ea9a5d9f592a178ea054053a70289"
-  integrity sha512-LKJltc4LVdMKHsrFe4MGNPp0hqDFA1Wpt3jE1gEyM3nKUvOiO//9PheZZHfYRfYl6AwdTH4aTcXSqBerX0ml4A==
 
 "@esbuild/linux-mips64el@0.17.8":
   version "0.17.8"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.17.8.tgz#f2b0d36e63fb26bc3f95b203b6a80638292101ca"
   integrity sha512-CCb67RKahNobjm/eeEqeD/oJfJlrWyw29fgiyB6vcgyq97YAf3gCOuP6qMShYSPXgnlZe/i4a8WFHBw6N8bYAA==
 
-"@esbuild/linux-ppc64@0.17.18":
-  version "0.17.18"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.17.18.tgz#3d9deb60b2d32c9985bdc3e3be090d30b7472783"
-  integrity sha512-3dLlQO+b/LnQNxgH4l9rqa2/IwRJVN9u/bK63FhOPB4xqiRqlQAU0qDU3JJuf0BmaH0yytTBdoSBHrb2jqc5qQ==
-
-"@esbuild/linux-ppc64@0.17.19":
-  version "0.17.19"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.17.19.tgz#876590e3acbd9fa7f57a2c7d86f83717dbbac8c7"
-  integrity sha512-/c/DGybs95WXNS8y3Ti/ytqETiW7EU44MEKuCAcpPto3YjQbyK3IQVKfF6nbghD7EcLUGl0NbiL5Rt5DMhn5tg==
-
 "@esbuild/linux-ppc64@0.17.8":
   version "0.17.8"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.17.8.tgz#1e628be003e036e90423716028cc884fe5ba25bd"
   integrity sha512-bytLJOi55y55+mGSdgwZ5qBm0K9WOCh0rx+vavVPx+gqLLhxtSFU0XbeYy/dsAAD6xECGEv4IQeFILaSS2auXw==
-
-"@esbuild/linux-riscv64@0.17.18":
-  version "0.17.18"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.17.18.tgz#8a943cf13fd24ff7ed58aefb940ef178f93386bc"
-  integrity sha512-/x7leOyDPjZV3TcsdfrSI107zItVnsX1q2nho7hbbQoKnmoeUWjs+08rKKt4AUXju7+3aRZSsKrJtaRmsdL1xA==
-
-"@esbuild/linux-riscv64@0.17.19":
-  version "0.17.19"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.17.19.tgz#7f49373df463cd9f41dc34f9b2262d771688bf09"
-  integrity sha512-FC3nUAWhvFoutlhAkgHf8f5HwFWUL6bYdvLc/TTuxKlvLi3+pPzdZiFKSWz/PF30TB1K19SuCxDTI5KcqASJqA==
 
 "@esbuild/linux-riscv64@0.17.8":
   version "0.17.8"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.17.8.tgz#419a815cb4c3fb9f1b78ef5295f5b48b8bf6427a"
   integrity sha512-2YpRyQJmKVBEHSBLa8kBAtbhucaclb6ex4wchfY0Tj3Kg39kpjeJ9vhRU7x4mUpq8ISLXRXH1L0dBYjAeqzZAw==
 
-"@esbuild/linux-s390x@0.17.18":
-  version "0.17.18"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.17.18.tgz#66cb01f4a06423e5496facabdce4f7cae7cb80e5"
-  integrity sha512-cX0I8Q9xQkL/6F5zWdYmVf5JSQt+ZfZD2bJudZrWD+4mnUvoZ3TDDXtDX2mUaq6upMFv9FlfIh4Gfun0tbGzuw==
-
-"@esbuild/linux-s390x@0.17.19":
-  version "0.17.19"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.17.19.tgz#e2afd1afcaf63afe2c7d9ceacd28ec57c77f8829"
-  integrity sha512-IbFsFbxMWLuKEbH+7sTkKzL6NJmG2vRyy6K7JJo55w+8xDk7RElYn6xvXtDW8HCfoKBFK69f3pgBJSUSQPr+4Q==
-
 "@esbuild/linux-s390x@0.17.8":
   version "0.17.8"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.17.8.tgz#291c49ae5c3d11d226352755c0835911fe1a9e5c"
   integrity sha512-QgbNY/V3IFXvNf11SS6exkpVcX0LJcob+0RWCgV9OiDAmVElnxciHIisoSix9uzYzScPmS6dJFbZULdSAEkQVw==
-
-"@esbuild/linux-x64@0.17.18":
-  version "0.17.18"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.17.18.tgz#23c26050c6c5d1359c7b774823adc32b3883b6c9"
-  integrity sha512-66RmRsPlYy4jFl0vG80GcNRdirx4nVWAzJmXkevgphP1qf4dsLQCpSKGM3DUQCojwU1hnepI63gNZdrr02wHUA==
-
-"@esbuild/linux-x64@0.17.19":
-  version "0.17.19"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.17.19.tgz#8a0e9738b1635f0c53389e515ae83826dec22aa4"
-  integrity sha512-68ngA9lg2H6zkZcyp22tsVt38mlhWde8l3eJLWkyLrp4HwMUr3c1s/M2t7+kHIhvMjglIBrFpncX1SzMckomGw==
 
 "@esbuild/linux-x64@0.17.8":
   version "0.17.8"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.17.8.tgz#03199d91c76faf80bd54104f5cbf0a489bc39f6a"
   integrity sha512-mM/9S0SbAFDBc4OPoyP6SEOo5324LpUxdpeIUUSrSTOfhHU9hEfqRngmKgqILqwx/0DVJBzeNW7HmLEWp9vcOA==
 
-"@esbuild/netbsd-x64@0.17.18":
-  version "0.17.18"
-  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.17.18.tgz#789a203d3115a52633ff6504f8cbf757f15e703b"
-  integrity sha512-95IRY7mI2yrkLlTLb1gpDxdC5WLC5mZDi+kA9dmM5XAGxCME0F8i4bYH4jZreaJ6lIZ0B8hTrweqG1fUyW7jbg==
-
-"@esbuild/netbsd-x64@0.17.19":
-  version "0.17.19"
-  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.17.19.tgz#c29fb2453c6b7ddef9a35e2c18b37bda1ae5c462"
-  integrity sha512-CwFq42rXCR8TYIjIfpXCbRX0rp1jo6cPIUPSaWwzbVI4aOfX96OXY8M6KNmtPcg7QjYeDmN+DD0Wp3LaBOLf4Q==
-
 "@esbuild/netbsd-x64@0.17.8":
   version "0.17.8"
   resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.17.8.tgz#b436d767e1b21852f9ed212e2bb57f77203b0ae2"
   integrity sha512-eKUYcWaWTaYr9zbj8GertdVtlt1DTS1gNBWov+iQfWuWyuu59YN6gSEJvFzC5ESJ4kMcKR0uqWThKUn5o8We6Q==
-
-"@esbuild/openbsd-x64@0.17.18":
-  version "0.17.18"
-  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.17.18.tgz#d7b998a30878f8da40617a10af423f56f12a5e90"
-  integrity sha512-WevVOgcng+8hSZ4Q3BKL3n1xTv5H6Nb53cBrtzzEjDbbnOmucEVcZeGCsCOi9bAOcDYEeBZbD2SJNBxlfP3qiA==
-
-"@esbuild/openbsd-x64@0.17.19":
-  version "0.17.19"
-  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.17.19.tgz#95e75a391403cb10297280d524d66ce04c920691"
-  integrity sha512-cnq5brJYrSZ2CF6c35eCmviIN3k3RczmHz8eYaVlNasVqsNY+JKohZU5MKmaOI+KkllCdzOKKdPs762VCPC20g==
 
 "@esbuild/openbsd-x64@0.17.8":
   version "0.17.8"
   resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.17.8.tgz#d1481d8539e21d4729cd04a0450a26c2c8789e89"
   integrity sha512-Vc9J4dXOboDyMXKD0eCeW0SIeEzr8K9oTHJU+Ci1mZc5njPfhKAqkRt3B/fUNU7dP+mRyralPu8QUkiaQn7iIg==
 
-"@esbuild/sunos-x64@0.17.18":
-  version "0.17.18"
-  resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.17.18.tgz#ecad0736aa7dae07901ba273db9ef3d3e93df31f"
-  integrity sha512-Rzf4QfQagnwhQXVBS3BYUlxmEbcV7MY+BH5vfDZekU5eYpcffHSyjU8T0xucKVuOcdCsMo+Ur5wmgQJH2GfNrg==
-
-"@esbuild/sunos-x64@0.17.19":
-  version "0.17.19"
-  resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.17.19.tgz#722eaf057b83c2575937d3ffe5aeb16540da7273"
-  integrity sha512-vCRT7yP3zX+bKWFeP/zdS6SqdWB8OIpaRq/mbXQxTGHnIxspRtigpkUcDMlSCOejlHowLqII7K2JKevwyRP2rg==
-
 "@esbuild/sunos-x64@0.17.8":
   version "0.17.8"
   resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.17.8.tgz#2cfb8126e079b2c00fd1bf095541e9f5c47877e4"
   integrity sha512-0xvOTNuPXI7ft1LYUgiaXtpCEjp90RuBBYovdd2lqAFxje4sEucurg30M1WIm03+3jxByd3mfo+VUmPtRSVuOw==
-
-"@esbuild/win32-arm64@0.17.18":
-  version "0.17.18"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.17.18.tgz#58dfc177da30acf956252d7c8ae9e54e424887c4"
-  integrity sha512-Kb3Ko/KKaWhjeAm2YoT/cNZaHaD1Yk/pa3FTsmqo9uFh1D1Rfco7BBLIPdDOozrObj2sahslFuAQGvWbgWldAg==
-
-"@esbuild/win32-arm64@0.17.19":
-  version "0.17.19"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.17.19.tgz#9aa9dc074399288bdcdd283443e9aeb6b9552b6f"
-  integrity sha512-yYx+8jwowUstVdorcMdNlzklLYhPxjniHWFKgRqH7IFlUEa0Umu3KuYplf1HUZZ422e3NU9F4LGb+4O0Kdcaag==
 
 "@esbuild/win32-arm64@0.17.8":
   version "0.17.8"
   resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.17.8.tgz#7c6ecfd097ca23b82119753bf7072bbaefe51e3a"
   integrity sha512-G0JQwUI5WdEFEnYNKzklxtBheCPkuDdu1YrtRrjuQv30WsYbkkoixKxLLv8qhJmNI+ATEWquZe/N0d0rpr55Mg==
 
-"@esbuild/win32-ia32@0.17.18":
-  version "0.17.18"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.17.18.tgz#340f6163172b5272b5ae60ec12c312485f69232b"
-  integrity sha512-0/xUMIdkVHwkvxfbd5+lfG7mHOf2FRrxNbPiKWg9C4fFrB8H0guClmaM3BFiRUYrznVoyxTIyC/Ou2B7QQSwmw==
-
-"@esbuild/win32-ia32@0.17.19":
-  version "0.17.19"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.17.19.tgz#95ad43c62ad62485e210f6299c7b2571e48d2b03"
-  integrity sha512-eggDKanJszUtCdlVs0RB+h35wNlb5v4TWEkq4vZcmVt5u/HiDZrTXe2bWFQUez3RgNHwx/x4sk5++4NSSicKkw==
-
 "@esbuild/win32-ia32@0.17.8":
   version "0.17.8"
   resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.17.8.tgz#cffec63c3cb0ef8563a04df4e09fa71056171d00"
   integrity sha512-Fqy63515xl20OHGFykjJsMnoIWS+38fqfg88ClvPXyDbLtgXal2DTlhb1TfTX34qWi3u4I7Cq563QcHpqgLx8w==
-
-"@esbuild/win32-x64@0.17.18":
-  version "0.17.18"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.17.18.tgz#3a8e57153905308db357fd02f57c180ee3a0a1fa"
-  integrity sha512-qU25Ma1I3NqTSHJUOKi9sAH1/Mzuvlke0ioMJRthLXKm7JiSKVwFghlGbDLOO2sARECGhja4xYfRAZNPAkooYg==
-
-"@esbuild/win32-x64@0.17.19":
-  version "0.17.19"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.17.19.tgz#8cfaf2ff603e9aabb910e9c0558c26cf32744061"
-  integrity sha512-lAhycmKnVOuRYNtRtatQR1LPQf2oYCkRGkSFnseDAKPl8lu5SOsK/e1sXe5a0Pc5kHIHe6P2I/ilntNv2xf3cA==
 
 "@esbuild/win32-x64@0.17.8":
   version "0.17.8"
@@ -1986,11 +1523,6 @@
   version "15.2.8"
   resolved "https://registry.yarnpkg.com/@ngtools/webpack/-/webpack-15.2.8.tgz#df8fb9300ccf94cab8f8ad69fb16fd31181e6c82"
   integrity sha512-BJexeT4FxMtToVBGa3wdl6rrkYXgilP0kkSH4Qzu4MPlLPbeBSr4XQalQriewlpC2uzG0r2SJfrAe2eDhtSykA==
-
-"@ngtools/webpack@16.0.5":
-  version "16.0.5"
-  resolved "https://registry.yarnpkg.com/@ngtools/webpack/-/webpack-16.0.5.tgz#4a2f4e5b02984e69fbfdabd8a5c7da14191734b3"
-  integrity sha512-qKQmPKxfcI9pumaKqM4EodcjauLA2JCGdAhBu+xafdmqV52K7goZKCqqzjYpraqeS+UOphi08XetX4mBPu9KMg==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -2261,7 +1793,7 @@
     "@types/estree" "*"
     "@types/json-schema" "*"
 
-"@types/estree@*", "@types/estree@^1.0.0":
+"@types/estree@*":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.1.tgz#aa22750962f3bf0e79d753d3cc067f010c95f194"
   integrity sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA==
@@ -2457,11 +1989,6 @@
   resolved "https://registry.yarnpkg.com/@types/yarnpkg__lockfile/-/yarnpkg__lockfile-1.1.6.tgz#60a35ede6197d8cbedd5bb8393f3921e8d56d44b"
   integrity sha512-kbdQa3J+hVCkqmGQm31fthEwGxszZtepw84p9QGCiJB7TmiPqPAf3/g9eZUnkCeanmiFOaG4pVhiPDyqJxaoaw==
 
-"@vitejs/plugin-basic-ssl@1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@vitejs/plugin-basic-ssl/-/plugin-basic-ssl-1.0.1.tgz#48c46eab21e0730921986ce742563ae83fe7fe34"
-  integrity sha512-pcub+YbFtFhaGRTo1832FQHQSHvMrlb43974e2eS8EKleR3p1cDdkJFPci1UhwkEf1J9Bz+wKBSzqpKp7nNj2A==
-
 "@webassemblyjs/ast@1.11.1":
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.11.1.tgz#2bfd767eae1a6996f432ff7e8d7fc75679c0b6a7"
@@ -2470,43 +1997,20 @@
     "@webassemblyjs/helper-numbers" "1.11.1"
     "@webassemblyjs/helper-wasm-bytecode" "1.11.1"
 
-"@webassemblyjs/ast@1.11.6", "@webassemblyjs/ast@^1.11.5":
-  version "1.11.6"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.11.6.tgz#db046555d3c413f8966ca50a95176a0e2c642e24"
-  integrity sha512-IN1xI7PwOvLPgjcf180gC1bqn3q/QaOCwYUahIOhbYUu8KA/3tw2RT/T0Gidi1l7Hhj5D/INhJxiICObqpMu4Q==
-  dependencies:
-    "@webassemblyjs/helper-numbers" "1.11.6"
-    "@webassemblyjs/helper-wasm-bytecode" "1.11.6"
-
 "@webassemblyjs/floating-point-hex-parser@1.11.1":
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.1.tgz#f6c61a705f0fd7a6aecaa4e8198f23d9dc179e4f"
   integrity sha512-iGRfyc5Bq+NnNuX8b5hwBrRjzf0ocrJPI6GWFodBFzmFnyvrQ83SHKhmilCU/8Jv67i4GJZBMhEzltxzcNagtQ==
-
-"@webassemblyjs/floating-point-hex-parser@1.11.6":
-  version "1.11.6"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.6.tgz#dacbcb95aff135c8260f77fa3b4c5fea600a6431"
-  integrity sha512-ejAj9hfRJ2XMsNHk/v6Fu2dGS+i4UaXBXGemOfQ/JfQ6mdQg/WXtwleQRLLS4OvfDhv8rYnVwH27YJLMyYsxhw==
 
 "@webassemblyjs/helper-api-error@1.11.1":
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.1.tgz#1a63192d8788e5c012800ba6a7a46c705288fd16"
   integrity sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg==
 
-"@webassemblyjs/helper-api-error@1.11.6":
-  version "1.11.6"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.6.tgz#6132f68c4acd59dcd141c44b18cbebbd9f2fa768"
-  integrity sha512-o0YkoP4pVu4rN8aTJgAyj9hC2Sv5UlkzCHhxqWj8butaLvnpdc2jOwh4ewE6CX0txSfLn/UYaV/pheS2Txg//Q==
-
 "@webassemblyjs/helper-buffer@1.11.1":
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.1.tgz#832a900eb444884cde9a7cad467f81500f5e5ab5"
   integrity sha512-gwikF65aDNeeXa8JxXa2BAk+REjSyhrNC9ZwdT0f8jc4dQQeDQ7G4m0f2QCLPJiMTTO6wfDmRmj/pW0PsUvIcA==
-
-"@webassemblyjs/helper-buffer@1.11.6":
-  version "1.11.6"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.6.tgz#b66d73c43e296fd5e88006f18524feb0f2c7c093"
-  integrity sha512-z3nFzdcp1mb8nEOFFk8DrYLpHvhKC3grJD2ardfKOzmbmJvEf/tPIqCY+sNcwZIY8ZD7IkB2l7/pqhUhqm7hLA==
 
 "@webassemblyjs/helper-numbers@1.11.1":
   version "1.11.1"
@@ -2517,24 +2021,10 @@
     "@webassemblyjs/helper-api-error" "1.11.1"
     "@xtuc/long" "4.2.2"
 
-"@webassemblyjs/helper-numbers@1.11.6":
-  version "1.11.6"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.6.tgz#cbce5e7e0c1bd32cf4905ae444ef64cea919f1b5"
-  integrity sha512-vUIhZ8LZoIWHBohiEObxVm6hwP034jwmc9kuq5GdHZH0wiLVLIPcMCdpJzG4C11cHoQ25TFIQj9kaVADVX7N3g==
-  dependencies:
-    "@webassemblyjs/floating-point-hex-parser" "1.11.6"
-    "@webassemblyjs/helper-api-error" "1.11.6"
-    "@xtuc/long" "4.2.2"
-
 "@webassemblyjs/helper-wasm-bytecode@1.11.1":
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.1.tgz#f328241e41e7b199d0b20c18e88429c4433295e1"
   integrity sha512-PvpoOGiJwXeTrSf/qfudJhwlvDQxFgelbMqtq52WWiXC6Xgg1IREdngmPN3bs4RoO83PnL/nFrxucXj1+BX62Q==
-
-"@webassemblyjs/helper-wasm-bytecode@1.11.6":
-  version "1.11.6"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.6.tgz#bb2ebdb3b83aa26d9baad4c46d4315283acd51e9"
-  integrity sha512-sFFHKwcmBprO9e7Icf0+gddyWYDViL8bpPjJJl0WHxCdETktXdmtWLGVzoHbqUcY4Be1LkNfwTmXOJUFZYSJdA==
 
 "@webassemblyjs/helper-wasm-section@1.11.1":
   version "1.11.1"
@@ -2546,27 +2036,10 @@
     "@webassemblyjs/helper-wasm-bytecode" "1.11.1"
     "@webassemblyjs/wasm-gen" "1.11.1"
 
-"@webassemblyjs/helper-wasm-section@1.11.6":
-  version "1.11.6"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.6.tgz#ff97f3863c55ee7f580fd5c41a381e9def4aa577"
-  integrity sha512-LPpZbSOwTpEC2cgn4hTydySy1Ke+XEu+ETXuoyvuyezHO3Kjdu90KK95Sh9xTbmjrCsUwvWwCOQQNta37VrS9g==
-  dependencies:
-    "@webassemblyjs/ast" "1.11.6"
-    "@webassemblyjs/helper-buffer" "1.11.6"
-    "@webassemblyjs/helper-wasm-bytecode" "1.11.6"
-    "@webassemblyjs/wasm-gen" "1.11.6"
-
 "@webassemblyjs/ieee754@1.11.1":
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ieee754/-/ieee754-1.11.1.tgz#963929e9bbd05709e7e12243a099180812992614"
   integrity sha512-hJ87QIPtAMKbFq6CGTkZYJivEwZDbQUgYd3qKSadTNOhVY7p+gfP6Sr0lLRVTaG1JjFj+r3YchoqRYxNH3M0GQ==
-  dependencies:
-    "@xtuc/ieee754" "^1.2.0"
-
-"@webassemblyjs/ieee754@1.11.6":
-  version "1.11.6"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/ieee754/-/ieee754-1.11.6.tgz#bb665c91d0b14fffceb0e38298c329af043c6e3a"
-  integrity sha512-LM4p2csPNvbij6U1f19v6WR56QZ8JcHg3QIJTlSwzFcmx6WSORicYj6I63f9yU1kEUtrpG+kjkiIAkevHpDXrg==
   dependencies:
     "@xtuc/ieee754" "^1.2.0"
 
@@ -2577,22 +2050,10 @@
   dependencies:
     "@xtuc/long" "4.2.2"
 
-"@webassemblyjs/leb128@1.11.6":
-  version "1.11.6"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/leb128/-/leb128-1.11.6.tgz#70e60e5e82f9ac81118bc25381a0b283893240d7"
-  integrity sha512-m7a0FhE67DQXgouf1tbN5XQcdWoNgaAuoULHIfGFIEVKA6tu/edls6XnIlkmS6FrXAquJRPni3ZZKjw6FSPjPQ==
-  dependencies:
-    "@xtuc/long" "4.2.2"
-
 "@webassemblyjs/utf8@1.11.1":
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/utf8/-/utf8-1.11.1.tgz#d1f8b764369e7c6e6bae350e854dec9a59f0a3ff"
   integrity sha512-9kqcxAEdMhiwQkHpkNiorZzqpGrodQQ2IGrHHxCy+Ozng0ofyMA0lTqiLkVs1uzTRejX+/O0EOT7KxqVPuXosQ==
-
-"@webassemblyjs/utf8@1.11.6":
-  version "1.11.6"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/utf8/-/utf8-1.11.6.tgz#90f8bc34c561595fe156603be7253cdbcd0fab5a"
-  integrity sha512-vtXf2wTQ3+up9Zsg8sa2yWiQpzSsMyXj0qViVP6xKGCUT8p8YJ6HqI7l5eCnWx1T/FYdsv07HQs2wTFbbof/RA==
 
 "@webassemblyjs/wasm-edit@1.11.1":
   version "1.11.1"
@@ -2608,20 +2069,6 @@
     "@webassemblyjs/wasm-parser" "1.11.1"
     "@webassemblyjs/wast-printer" "1.11.1"
 
-"@webassemblyjs/wasm-edit@^1.11.5":
-  version "1.11.6"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.6.tgz#c72fa8220524c9b416249f3d94c2958dfe70ceab"
-  integrity sha512-Ybn2I6fnfIGuCR+Faaz7YcvtBKxvoLV3Lebn1tM4o/IAJzmi9AWYIPWpyBfU8cC+JxAO57bk4+zdsTjJR+VTOw==
-  dependencies:
-    "@webassemblyjs/ast" "1.11.6"
-    "@webassemblyjs/helper-buffer" "1.11.6"
-    "@webassemblyjs/helper-wasm-bytecode" "1.11.6"
-    "@webassemblyjs/helper-wasm-section" "1.11.6"
-    "@webassemblyjs/wasm-gen" "1.11.6"
-    "@webassemblyjs/wasm-opt" "1.11.6"
-    "@webassemblyjs/wasm-parser" "1.11.6"
-    "@webassemblyjs/wast-printer" "1.11.6"
-
 "@webassemblyjs/wasm-gen@1.11.1":
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.1.tgz#86c5ea304849759b7d88c47a32f4f039ae3c8f76"
@@ -2633,17 +2080,6 @@
     "@webassemblyjs/leb128" "1.11.1"
     "@webassemblyjs/utf8" "1.11.1"
 
-"@webassemblyjs/wasm-gen@1.11.6":
-  version "1.11.6"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.6.tgz#fb5283e0e8b4551cc4e9c3c0d7184a65faf7c268"
-  integrity sha512-3XOqkZP/y6B4F0PBAXvI1/bky7GryoogUtfwExeP/v7Nzwo1QLcq5oQmpKlftZLbT+ERUOAZVQjuNVak6UXjPA==
-  dependencies:
-    "@webassemblyjs/ast" "1.11.6"
-    "@webassemblyjs/helper-wasm-bytecode" "1.11.6"
-    "@webassemblyjs/ieee754" "1.11.6"
-    "@webassemblyjs/leb128" "1.11.6"
-    "@webassemblyjs/utf8" "1.11.6"
-
 "@webassemblyjs/wasm-opt@1.11.1":
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.1.tgz#657b4c2202f4cf3b345f8a4c6461c8c2418985f2"
@@ -2653,16 +2089,6 @@
     "@webassemblyjs/helper-buffer" "1.11.1"
     "@webassemblyjs/wasm-gen" "1.11.1"
     "@webassemblyjs/wasm-parser" "1.11.1"
-
-"@webassemblyjs/wasm-opt@1.11.6":
-  version "1.11.6"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.6.tgz#d9a22d651248422ca498b09aa3232a81041487c2"
-  integrity sha512-cOrKuLRE7PCe6AsOVl7WasYf3wbSo4CeOk6PkrjS7g57MFfVUF9u6ysQBBODX0LdgSvQqRiGz3CXvIDKcPNy4g==
-  dependencies:
-    "@webassemblyjs/ast" "1.11.6"
-    "@webassemblyjs/helper-buffer" "1.11.6"
-    "@webassemblyjs/wasm-gen" "1.11.6"
-    "@webassemblyjs/wasm-parser" "1.11.6"
 
 "@webassemblyjs/wasm-parser@1.11.1":
   version "1.11.1"
@@ -2676,32 +2102,12 @@
     "@webassemblyjs/leb128" "1.11.1"
     "@webassemblyjs/utf8" "1.11.1"
 
-"@webassemblyjs/wasm-parser@1.11.6", "@webassemblyjs/wasm-parser@^1.11.5":
-  version "1.11.6"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.6.tgz#bb85378c527df824004812bbdb784eea539174a1"
-  integrity sha512-6ZwPeGzMJM3Dqp3hCsLgESxBGtT/OeCvCZ4TA1JUPYgmhAx38tTPR9JaKy0S5H3evQpO/h2uWs2j6Yc/fjkpTQ==
-  dependencies:
-    "@webassemblyjs/ast" "1.11.6"
-    "@webassemblyjs/helper-api-error" "1.11.6"
-    "@webassemblyjs/helper-wasm-bytecode" "1.11.6"
-    "@webassemblyjs/ieee754" "1.11.6"
-    "@webassemblyjs/leb128" "1.11.6"
-    "@webassemblyjs/utf8" "1.11.6"
-
 "@webassemblyjs/wast-printer@1.11.1":
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/wast-printer/-/wast-printer-1.11.1.tgz#d0c73beda8eec5426f10ae8ef55cee5e7084c2f0"
   integrity sha512-IQboUWM4eKzWW+N/jij2sRatKMh99QEelo3Eb2q0qXkvPRISAj8Qxtmw5itwqK+TTkBuUIE45AxYPToqPtL5gg==
   dependencies:
     "@webassemblyjs/ast" "1.11.1"
-    "@xtuc/long" "4.2.2"
-
-"@webassemblyjs/wast-printer@1.11.6":
-  version "1.11.6"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/wast-printer/-/wast-printer-1.11.6.tgz#a7bf8dd7e362aeb1668ff43f35cb849f188eff20"
-  integrity sha512-JM7AhRcE+yW2GWYaKeHL5vt4xqee5N2WcezptmgyhNS+ScggqcT1OtXykhAb13Sn5Yas0j2uv9tHgrjwvzAP4A==
-  dependencies:
-    "@webassemblyjs/ast" "1.11.6"
     "@xtuc/long" "4.2.2"
 
 "@xtuc/ieee754@^1.2.0":
@@ -3045,18 +2451,6 @@ autoprefixer@10.4.13:
     picocolors "^1.0.0"
     postcss-value-parser "^4.2.0"
 
-autoprefixer@10.4.14:
-  version "10.4.14"
-  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-10.4.14.tgz#e28d49902f8e759dd25b153264e862df2705f79d"
-  integrity sha512-FQzyfOsTlwVzjHxKEqRIAdJx9niO6VCBCoEwax/VLSoQF29ggECcPuBqUMZ+u8jCZOPSy8b8/8KnuFbp0SaFZQ==
-  dependencies:
-    browserslist "^4.21.5"
-    caniuse-lite "^1.0.30001464"
-    fraction.js "^4.2.0"
-    normalize-range "^0.1.2"
-    picocolors "^1.0.0"
-    postcss-value-parser "^4.2.0"
-
 aws-sign2@~0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
@@ -3355,25 +2749,6 @@ cacache@17.0.4:
     tar "^6.1.11"
     unique-filename "^3.0.0"
 
-cacache@17.0.6:
-  version "17.0.6"
-  resolved "https://registry.yarnpkg.com/cacache/-/cacache-17.0.6.tgz#faf9739a067e6dcfd31316df82fdf7e1ec460373"
-  integrity sha512-ixcYmEBExFa/+ajIPjcwypxL97CjJyOsH9A/W+4qgEPIpJvKlC+HmVY8nkIck6n3PwUTdgq9c489niJGwl+5Cw==
-  dependencies:
-    "@npmcli/fs" "^3.1.0"
-    fs-minipass "^3.0.0"
-    glob "^10.2.2"
-    lru-cache "^7.7.1"
-    minipass "^5.0.0"
-    minipass-collect "^1.0.2"
-    minipass-flush "^1.0.5"
-    minipass-pipeline "^1.2.4"
-    p-map "^4.0.0"
-    promise-inflight "^1.0.1"
-    ssri "^10.0.0"
-    tar "^6.1.11"
-    unique-filename "^3.0.0"
-
 cacache@^16.1.0:
   version "16.1.3"
   resolved "https://registry.yarnpkg.com/cacache/-/cacache-16.1.3.tgz#a02b9f34ecfaf9a78c9f4bc16fceb94d5d67a38e"
@@ -3434,7 +2809,7 @@ camelcase@^5.0.0, camelcase@^5.3.1:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
-caniuse-lite@^1.0.30001426, caniuse-lite@^1.0.30001449, caniuse-lite@^1.0.30001464, caniuse-lite@^1.0.30001489:
+caniuse-lite@^1.0.30001426, caniuse-lite@^1.0.30001449, caniuse-lite@^1.0.30001489:
   version "1.0.30001495"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001495.tgz#64a0ccef1911a9dcff647115b4430f8eff1ef2d9"
   integrity sha512-F6x5IEuigtUfU5ZMQK2jsy5JqUUlEFRVZq8bO2a+ysq5K7jD6PPc9YXZj78xDNS3uNchesp1Jw47YXEqr+Viyg==
@@ -3883,11 +3258,6 @@ cors@~2.8.5:
     object-assign "^4"
     vary "^1"
 
-cosmiconfig-typescript-loader@^4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-4.3.0.tgz#c4259ce474c9df0f32274ed162c0447c951ef073"
-  integrity sha512-NTxV1MFfZDLPiBMjxbHRwSh5LaLcPMwNdCutmnHJCKoVnlvldPWlllonKwrsRJ5pYZBIBGRWWU2tfvzxgeSW5Q==
-
 cosmiconfig@^7.0.0:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-7.1.0.tgz#1443b9afa596b670082ea46cbd8f6a62b84635f6"
@@ -3898,16 +3268,6 @@ cosmiconfig@^7.0.0:
     parse-json "^5.0.0"
     path-type "^4.0.0"
     yaml "^1.10.0"
-
-cosmiconfig@^8.1.3:
-  version "8.2.0"
-  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-8.2.0.tgz#f7d17c56a590856cd1e7cee98734dca272b0d8fd"
-  integrity sha512-3rTMnFJA1tCOPwRxtgF4wd7Ab2qvDbL8jX+3smjIbS4HlZBagTlpERbdN7iAbWlrfxE3M8c27kTwTawQ7st+OQ==
-  dependencies:
-    import-fresh "^3.2.1"
-    js-yaml "^4.1.0"
-    parse-json "^5.0.0"
-    path-type "^4.0.0"
 
 create-require@^1.1.0:
   version "1.1.1"
@@ -4314,7 +3674,7 @@ engine.io@~6.4.2:
     engine.io-parser "~5.0.3"
     ws "~8.11.0"
 
-enhanced-resolve@^5.10.0, enhanced-resolve@^5.13.0:
+enhanced-resolve@^5.10.0:
   version "5.14.1"
   resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.14.1.tgz#de684b6803724477a4af5d74ccae5de52c25f6b3"
   integrity sha512-Vklwq2vDKtl0y/vtwjSesgJ5MYS7Etuk5txS8VdKL4AOS1aUlD96zqIfsOSLQsdv3xgMRbtkWM8eG9XDfKUPow==
@@ -4371,11 +3731,6 @@ es-module-lexer@^0.9.0:
   resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-0.9.3.tgz#6f13db00cc38417137daf74366f535c8eb438f19"
   integrity sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==
 
-es-module-lexer@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-1.2.1.tgz#ba303831f63e6a394983fde2f97ad77b22324527"
-  integrity sha512-9978wrXM50Y4rTMmW5kXIC09ZdXQZqkE4mxhwkd8VbzsGkXGPgV4zWuqQJgCEzYngdo2dYDa0l8xhX4fkSwJSg==
-
 es6-error@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/es6-error/-/es6-error-4.1.1.tgz#9e3af407459deed47e9a91f9b885a84eb05c561d"
@@ -4393,43 +3748,10 @@ es6-promisify@^5.0.0:
   dependencies:
     es6-promise "^4.0.3"
 
-esbuild-wasm@0.17.18:
-  version "0.17.18"
-  resolved "https://registry.yarnpkg.com/esbuild-wasm/-/esbuild-wasm-0.17.18.tgz#4d922c509eccfc33f7969c880a520e5e665681ef"
-  integrity sha512-h4m5zVa+KaDuRFIbH9dokMwovvkIjTQJS7/Ry+0Z1paVuS9aIkso2vdA2GmwH9GSvGX6w71WveJ3PfkoLuWaRw==
-
 esbuild-wasm@0.17.8:
   version "0.17.8"
   resolved "https://registry.yarnpkg.com/esbuild-wasm/-/esbuild-wasm-0.17.8.tgz#c2348306430c27613ee3cc9a955cdd54df29137a"
   integrity sha512-zCmpxv95E0FuCmvdw1K836UHnj4EdiQnFfjTby35y3LAjRPtXMj3sbHDRHjbD8Mqg5lTwq3knacr/1qIFU51CQ==
-
-esbuild@0.17.18:
-  version "0.17.18"
-  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.17.18.tgz#f4f8eb6d77384d68cd71c53eb6601c7efe05e746"
-  integrity sha512-z1lix43jBs6UKjcZVKOw2xx69ffE2aG0PygLL5qJ9OS/gy0Ewd1gW/PUQIOIQGXBHWNywSc0floSKoMFF8aK2w==
-  optionalDependencies:
-    "@esbuild/android-arm" "0.17.18"
-    "@esbuild/android-arm64" "0.17.18"
-    "@esbuild/android-x64" "0.17.18"
-    "@esbuild/darwin-arm64" "0.17.18"
-    "@esbuild/darwin-x64" "0.17.18"
-    "@esbuild/freebsd-arm64" "0.17.18"
-    "@esbuild/freebsd-x64" "0.17.18"
-    "@esbuild/linux-arm" "0.17.18"
-    "@esbuild/linux-arm64" "0.17.18"
-    "@esbuild/linux-ia32" "0.17.18"
-    "@esbuild/linux-loong64" "0.17.18"
-    "@esbuild/linux-mips64el" "0.17.18"
-    "@esbuild/linux-ppc64" "0.17.18"
-    "@esbuild/linux-riscv64" "0.17.18"
-    "@esbuild/linux-s390x" "0.17.18"
-    "@esbuild/linux-x64" "0.17.18"
-    "@esbuild/netbsd-x64" "0.17.18"
-    "@esbuild/openbsd-x64" "0.17.18"
-    "@esbuild/sunos-x64" "0.17.18"
-    "@esbuild/win32-arm64" "0.17.18"
-    "@esbuild/win32-ia32" "0.17.18"
-    "@esbuild/win32-x64" "0.17.18"
 
 esbuild@0.17.8:
   version "0.17.8"
@@ -4458,34 +3780,6 @@ esbuild@0.17.8:
     "@esbuild/win32-arm64" "0.17.8"
     "@esbuild/win32-ia32" "0.17.8"
     "@esbuild/win32-x64" "0.17.8"
-
-esbuild@^0.17.5:
-  version "0.17.19"
-  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.17.19.tgz#087a727e98299f0462a3d0bcdd9cd7ff100bd955"
-  integrity sha512-XQ0jAPFkK/u3LcVRcvVHQcTIqD6E2H1fvZMA5dQPSOWb3suUbWbfbRf94pjc0bNzRYLfIrDRQXr7X+LHIm5oHw==
-  optionalDependencies:
-    "@esbuild/android-arm" "0.17.19"
-    "@esbuild/android-arm64" "0.17.19"
-    "@esbuild/android-x64" "0.17.19"
-    "@esbuild/darwin-arm64" "0.17.19"
-    "@esbuild/darwin-x64" "0.17.19"
-    "@esbuild/freebsd-arm64" "0.17.19"
-    "@esbuild/freebsd-x64" "0.17.19"
-    "@esbuild/linux-arm" "0.17.19"
-    "@esbuild/linux-arm64" "0.17.19"
-    "@esbuild/linux-ia32" "0.17.19"
-    "@esbuild/linux-loong64" "0.17.19"
-    "@esbuild/linux-mips64el" "0.17.19"
-    "@esbuild/linux-ppc64" "0.17.19"
-    "@esbuild/linux-riscv64" "0.17.19"
-    "@esbuild/linux-s390x" "0.17.19"
-    "@esbuild/linux-x64" "0.17.19"
-    "@esbuild/netbsd-x64" "0.17.19"
-    "@esbuild/openbsd-x64" "0.17.19"
-    "@esbuild/sunos-x64" "0.17.19"
-    "@esbuild/win32-arm64" "0.17.19"
-    "@esbuild/win32-ia32" "0.17.19"
-    "@esbuild/win32-x64" "0.17.19"
 
 escalade@^3.1.1:
   version "3.1.1"
@@ -5951,7 +5245,7 @@ klaw@^1.0.0:
   optionalDependencies:
     graceful-fs "^4.1.9"
 
-klona@^2.0.4, klona@^2.0.5, klona@^2.0.6:
+klona@^2.0.4, klona@^2.0.5:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/klona/-/klona-2.0.6.tgz#85bffbf819c03b2f53270412420a4555ef882e22"
   integrity sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA==
@@ -6080,7 +5374,7 @@ lodash.isequal@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
   integrity sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==
 
-lodash@4.17.21, lodash@^4.0.1, lodash@^4.17.15, lodash@^4.17.21:
+lodash@4.17.21, lodash@^4.0.1, lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -6157,13 +5451,6 @@ magic-string@0.29.0:
   version "0.29.0"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.29.0.tgz#f034f79f8c43dba4ae1730ffb5e8c4e084b16cf3"
   integrity sha512-WcfidHrDjMY+eLjlU+8OvwREqHwpgCeKVBUpQ3OhYYuvfaYCUgcbuBzappNzZvg/v8onU3oQj+BYpkOJe9Iw4Q==
-  dependencies:
-    "@jridgewell/sourcemap-codec" "^1.4.13"
-
-magic-string@0.30.0:
-  version "0.30.0"
-  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.0.tgz#fd58a4748c5c4547338a424e90fa5dd17f4de529"
-  integrity sha512-LA+31JYDJLs82r2ScLrlz1GjSgu66ZV518eyWT+S8VhyQn/JL0u9MeBOvQMGYiPk1DBiSN9DDMOcXvigJZaViQ==
   dependencies:
     "@jridgewell/sourcemap-codec" "^1.4.13"
 
@@ -6339,13 +5626,6 @@ mini-css-extract-plugin@2.7.2:
   dependencies:
     schema-utils "^4.0.0"
 
-mini-css-extract-plugin@2.7.5:
-  version "2.7.5"
-  resolved "https://registry.yarnpkg.com/mini-css-extract-plugin/-/mini-css-extract-plugin-2.7.5.tgz#afbb344977659ec0f1f6e050c7aea456b121cfc5"
-  integrity sha512-9HaR++0mlgom81s95vvNjxkg52n2b5s//3ZTI1EtzFb98awsLSivs2LMsVqnQ3ay0PVhqWcGNyDaTE961FOcjQ==
-  dependencies:
-    schema-utils "^4.0.0"
-
 minimalistic-assert@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
@@ -6496,11 +5776,6 @@ moment@^2.10.2, moment@^2.29.4:
   version "2.29.4"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.4.tgz#3dbe052889fe7c1b2ed966fcb3a77328964ef108"
   integrity sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==
-
-mrmime@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/mrmime/-/mrmime-1.0.1.tgz#5f90c825fad4bdd41dc914eff5d1a8cfdaf24f27"
-  integrity sha512-hzzEagAgDyoU1Q6yg5uI+AorQgdvMCur3FcKf7NhMKWsaYg+RnbTyHRa/9IlLF9rf455MOCtcqqrQQ83pPP7Uw==
 
 ms@2.0.0:
   version "2.0.0"
@@ -6850,7 +6125,7 @@ open@8.4.1:
     is-docker "^2.1.1"
     is-wsl "^2.2.0"
 
-open@8.4.2, open@^8.0.9:
+open@^8.0.9:
   version "8.4.2"
   resolved "https://registry.yarnpkg.com/open/-/open-8.4.2.tgz#5b5ffe2a8f793dcd2aad73e550cb87b59cb084f9"
   integrity sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==
@@ -7147,7 +6422,7 @@ picocolors@^1.0.0:
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
   integrity sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==
 
-picomatch@2.3.1, picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.3.1:
+picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
@@ -7208,16 +6483,6 @@ postcss-loader@7.0.2:
     klona "^2.0.5"
     semver "^7.3.8"
 
-postcss-loader@7.2.4:
-  version "7.2.4"
-  resolved "https://registry.yarnpkg.com/postcss-loader/-/postcss-loader-7.2.4.tgz#2884f4ca172de633b2cf1f93dc852968f0632ba9"
-  integrity sha512-F88rpxxNspo5hatIc+orYwZDtHFaVFOSIVAx+fBfJC1GmhWbVmPWtmg2gXKE1OxJbneOSGn8PWdIwsZFcruS+w==
-  dependencies:
-    cosmiconfig "^8.1.3"
-    cosmiconfig-typescript-loader "^4.3.0"
-    klona "^2.0.6"
-    semver "^7.3.8"
-
 postcss-modules-extract-imports@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz#cda1f047c0ae80c97dbe28c3e76a43b88025741d"
@@ -7268,16 +6533,7 @@ postcss@8.4.21:
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
 
-postcss@8.4.23:
-  version "8.4.23"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.23.tgz#df0aee9ac7c5e53e1075c24a3613496f9e6552ab"
-  integrity sha512-bQ3qMcpF6A/YjR55xtoTr0jGOlnPOKAIMdOWiv0EIT6HVPEaJiJB4NLljSbiHoC2RX7DN5Uvjtpbg1NPdwv1oA==
-  dependencies:
-    nanoid "^3.3.6"
-    picocolors "^1.0.0"
-    source-map-js "^1.0.2"
-
-postcss@^8.2.14, postcss@^8.3.7, postcss@^8.4.19, postcss@^8.4.23:
+postcss@^8.2.14, postcss@^8.3.7, postcss@^8.4.19:
   version "8.4.24"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.24.tgz#f714dba9b2284be3cc07dbd2fc57ee4dc972d2df"
   integrity sha512-M0RzbcI0sO/XJNucsGjvWU9ERWxb/ytp1w6dKtxTKgixdtQDq4rmx/g8W1hnaheq9jgwL/oyEdH5Bc4WwJKMqg==
@@ -7762,13 +7018,6 @@ roarr@^2.15.3:
     semver-compare "^1.0.0"
     sprintf-js "^1.1.2"
 
-rollup@^3.21.0:
-  version "3.24.0"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-3.24.0.tgz#865dee1fe0bb528747b59914dfab25e6f480e370"
-  integrity sha512-OgraHOIg2YpHQTjl0/ymWfFNBEyPucB7lmhXrQUh38qNOegxLapSPFs9sNr0qKR75awW41D93XafoR2QfhBdUQ==
-  optionalDependencies:
-    fsevents "~2.3.2"
-
 run-async@^2.4.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.4.1.tgz#8440eccf99ea3e70bd409d49aab88e10c189a455"
@@ -7800,7 +7049,7 @@ rxjs@6.6.7, rxjs@^6.5.3:
   dependencies:
     tslib "^1.9.0"
 
-rxjs@7.8.1, rxjs@^7.5.5, rxjs@^7.8.1:
+rxjs@^7.5.5, rxjs@^7.8.1:
   version "7.8.1"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.8.1.tgz#6f6f3d99ea8044291efd92e7c7fcf562c4057543"
   integrity sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==
@@ -7830,27 +7079,10 @@ sass-loader@13.2.0:
     klona "^2.0.4"
     neo-async "^2.6.2"
 
-sass-loader@13.2.2:
-  version "13.2.2"
-  resolved "https://registry.yarnpkg.com/sass-loader/-/sass-loader-13.2.2.tgz#f97e803993b24012c10d7ba9676548bf7a6b18b9"
-  integrity sha512-nrIdVAAte3B9icfBiGWvmMhT/D+eCDwnk+yA7VE/76dp/WkHX+i44Q/pfo71NYbwj0Ap+PGsn0ekOuU1WFJ2AA==
-  dependencies:
-    klona "^2.0.6"
-    neo-async "^2.6.2"
-
 sass@1.58.1:
   version "1.58.1"
   resolved "https://registry.yarnpkg.com/sass/-/sass-1.58.1.tgz#17ab0390076a50578ed0733f1cc45429e03405f6"
   integrity sha512-bnINi6nPXbP1XNRaranMFEBZWUfdW/AF16Ql5+ypRxfTvCRTTKrLsMIakyDcayUt2t/RZotmL4kgJwNH5xO+bg==
-  dependencies:
-    chokidar ">=3.0.0 <4.0.0"
-    immutable "^4.0.0"
-    source-map-js ">=0.6.2 <2.0.0"
-
-sass@1.62.1:
-  version "1.62.1"
-  resolved "https://registry.yarnpkg.com/sass/-/sass-1.62.1.tgz#caa8d6bf098935bc92fc73fa169fb3790cacd029"
-  integrity sha512-NHpxIzN29MXvWiuswfc1W3I0N8SXBd8UR26WntmDlRYf0bSADnwnOjsyMZ3lMezSlArD33Vs3YFhp7dWvL770A==
   dependencies:
     chokidar ">=3.0.0 <4.0.0"
     immutable "^4.0.0"
@@ -7872,15 +7104,6 @@ schema-utils@^3.1.0, schema-utils@^3.1.1:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-3.1.2.tgz#36c10abca6f7577aeae136c804b0c741edeadc99"
   integrity sha512-pvjEHOgWc9OWA/f/DE3ohBWTD6EleVLf7iFUkoSwAxttdBhB9QUebQgxER2kWueOvRJXPHNnyrvvh9eZINB8Eg==
-  dependencies:
-    "@types/json-schema" "^7.0.8"
-    ajv "^6.12.5"
-    ajv-keywords "^3.5.2"
-
-schema-utils@^3.1.2:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-3.2.0.tgz#7dff4881064a4f22c09f0c6a1457feb820fd0636"
-  integrity sha512-0zTyLGyDJYd/MBxG1AhJkKa6fpEBds4OQO2ut0w7OYG+ZGhGea09lijvzsqegYSik88zc7cUtIlnnO+/BvD6gQ==
   dependencies:
     "@types/json-schema" "^7.0.8"
     ajv "^6.12.5"
@@ -7934,13 +7157,6 @@ semver@7.3.8:
   version "7.3.8"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.8.tgz#07a78feafb3f7b32347d725e33de7e2a2df67798"
   integrity sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==
-  dependencies:
-    lru-cache "^6.0.0"
-
-semver@7.4.0:
-  version "7.4.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.4.0.tgz#8481c92feffc531ab1e012a8ffc15bdd3a0f4318"
-  integrity sha512-RgOxM8Mw+7Zus0+zcLEUn8+JfoLpj/huFTItQy2hsM4khuC1HYRDp0cU482Ewn/Fcy6bCjufD8vAj7voC66KQw==
   dependencies:
     lru-cache "^6.0.0"
 
@@ -8424,11 +7640,6 @@ strip-ansi@^7.0.1:
   dependencies:
     ansi-regex "^6.0.1"
 
-strip-bom@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
-  integrity sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==
-
 strip-eof@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
@@ -8520,7 +7731,7 @@ tar@^6.1.11, tar@^6.1.2:
     mkdirp "^1.0.3"
     yallist "^4.0.0"
 
-terser-webpack-plugin@^5.1.3, terser-webpack-plugin@^5.3.7:
+terser-webpack-plugin@^5.1.3:
   version "5.3.9"
   resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-5.3.9.tgz#832536999c51b46d468067f9e37662a3b96adfe1"
   integrity sha512-ZuXsqE07EcggTWQjXUj+Aot/OMcD0bMKGgF63f7UxYcu5/AJF53aIpK1YoP5xR9l6s/Hy2b+t1AM0bLNPRuhwA==
@@ -8535,16 +7746,6 @@ terser@5.16.3:
   version "5.16.3"
   resolved "https://registry.yarnpkg.com/terser/-/terser-5.16.3.tgz#3266017a9b682edfe019b8ecddd2abaae7b39c6b"
   integrity sha512-v8wWLaS/xt3nE9dgKEWhNUFP6q4kngO5B8eYFUuebsu7Dw/UNAnpUod6UHo04jSSkv8TzKHjZDSd7EXdDQAl8Q==
-  dependencies:
-    "@jridgewell/source-map" "^0.3.2"
-    acorn "^8.5.0"
-    commander "^2.20.0"
-    source-map-support "~0.5.20"
-
-terser@5.17.1:
-  version "5.17.1"
-  resolved "https://registry.yarnpkg.com/terser/-/terser-5.17.1.tgz#948f10830454761e2eeedc6debe45c532c83fd69"
-  integrity sha512-hVl35zClmpisy6oaoKALOpS0rDYLxRFLHhRuDlEGTKey9qHjS1w9GMORjuwIMt70Wan4lwsLYyWDVnWgF+KUEw==
   dependencies:
     "@jridgewell/source-map" "^0.3.2"
     acorn "^8.5.0"
@@ -8641,7 +7842,7 @@ tree-kill@1.2.2:
   resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.2.tgz#4ca09a9092c88b73a7cdc5e8a01b507b0790a0cc"
   integrity sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==
 
-ts-node@^10.0.0, ts-node@~10.9.1:
+ts-node@~10.9.1:
   version "10.9.1"
   resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.9.1.tgz#e73de9102958af9e1f0b168a6ff320e25adcff4b"
   integrity sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==
@@ -8659,15 +7860,6 @@ ts-node@^10.0.0, ts-node@~10.9.1:
     make-error "^1.1.1"
     v8-compile-cache-lib "^3.0.1"
     yn "3.1.1"
-
-tsconfig-paths@^4.1.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz#ef78e19039133446d244beac0fd6a1632e2d107c"
-  integrity sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==
-  dependencies:
-    json5 "^2.2.2"
-    minimist "^1.2.6"
-    strip-bom "^3.0.0"
 
 tslib@2.5.0:
   version "2.5.0"
@@ -8925,17 +8117,6 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-vite@4.3.9:
-  version "4.3.9"
-  resolved "https://registry.yarnpkg.com/vite/-/vite-4.3.9.tgz#db896200c0b1aa13b37cdc35c9e99ee2fdd5f96d"
-  integrity sha512-qsTNZjO9NoJNW7KnOrgYwczm0WctJ8m/yqYAMAK9Lxt4SoySUfS5S8ia9K7JHpa3KEeMfyF8LoJ3c5NeBJy6pg==
-  dependencies:
-    esbuild "^0.17.5"
-    postcss "^8.4.23"
-    rollup "^3.21.0"
-  optionalDependencies:
-    fsevents "~2.3.2"
-
 vlq@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/vlq/-/vlq-1.0.1.tgz#c003f6e7c0b4c1edd623fd6ee50bbc0d6a1de468"
@@ -9022,17 +8203,6 @@ webpack-dev-middleware@6.0.1:
     range-parser "^1.2.1"
     schema-utils "^4.0.0"
 
-webpack-dev-middleware@6.0.2:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/webpack-dev-middleware/-/webpack-dev-middleware-6.0.2.tgz#4aab69257378e01d6fe964a8b2d07e8a87623ebc"
-  integrity sha512-iOddiJzPcQC6lwOIu60vscbGWth8PCRcWRCwoQcTQf9RMoOWBHg5EyzpGdtSmGMrSPd5vHEfFXmVErQEmkRngQ==
-  dependencies:
-    colorette "^2.0.10"
-    memfs "^3.4.12"
-    mime-types "^2.1.31"
-    range-parser "^1.2.1"
-    schema-utils "^4.0.0"
-
 webpack-dev-middleware@^5.3.1:
   version "5.3.3"
   resolved "https://registry.yarnpkg.com/webpack-dev-middleware/-/webpack-dev-middleware-5.3.3.tgz#efae67c2793908e7311f1d9b06f2a08dcc97e51f"
@@ -9079,42 +8249,6 @@ webpack-dev-server@4.11.1:
     webpack-dev-middleware "^5.3.1"
     ws "^8.4.2"
 
-webpack-dev-server@4.13.2:
-  version "4.13.2"
-  resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-4.13.2.tgz#d97445481d78691efe6d9a3b230833d802fc31f9"
-  integrity sha512-5i6TrGBRxG4vnfDpB6qSQGfnB6skGBXNL5/542w2uRGLimX6qeE5BQMLrzIC3JYV/xlGOv+s+hTleI9AZKUQNw==
-  dependencies:
-    "@types/bonjour" "^3.5.9"
-    "@types/connect-history-api-fallback" "^1.3.5"
-    "@types/express" "^4.17.13"
-    "@types/serve-index" "^1.9.1"
-    "@types/serve-static" "^1.13.10"
-    "@types/sockjs" "^0.3.33"
-    "@types/ws" "^8.5.1"
-    ansi-html-community "^0.0.8"
-    bonjour-service "^1.0.11"
-    chokidar "^3.5.3"
-    colorette "^2.0.10"
-    compression "^1.7.4"
-    connect-history-api-fallback "^2.0.0"
-    default-gateway "^6.0.3"
-    express "^4.17.3"
-    graceful-fs "^4.2.6"
-    html-entities "^2.3.2"
-    http-proxy-middleware "^2.0.3"
-    ipaddr.js "^2.0.1"
-    launch-editor "^2.6.0"
-    open "^8.0.9"
-    p-retry "^4.5.0"
-    rimraf "^3.0.2"
-    schema-utils "^4.0.0"
-    selfsigned "^2.1.1"
-    serve-index "^1.9.1"
-    sockjs "^0.3.24"
-    spdy "^4.0.2"
-    webpack-dev-middleware "^5.3.1"
-    ws "^8.13.0"
-
 webpack-dev-server@^4.15.0:
   version "4.15.0"
   resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-4.15.0.tgz#87ba9006eca53c551607ea0d663f4ae88be7af21"
@@ -9159,14 +8293,6 @@ webpack-merge@5.8.0:
     clone-deep "^4.0.1"
     wildcard "^2.0.0"
 
-webpack-merge@^5.7.3:
-  version "5.9.0"
-  resolved "https://registry.yarnpkg.com/webpack-merge/-/webpack-merge-5.9.0.tgz#dc160a1c4cf512ceca515cc231669e9ddb133826"
-  integrity sha512-6NbRQw4+Sy50vYNTw7EyOn41OZItPiXB8GNv3INSoe3PSFaHJEz3SHTrYVaRm2LilNGnFUzh0FAwqPEmU/CwDg==
-  dependencies:
-    clone-deep "^4.0.1"
-    wildcard "^2.0.0"
-
 webpack-sources@^3.0.0, webpack-sources@^3.2.3:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-3.2.3.tgz#2d4daab8451fd4b240cc27055ff6a0c2ccea0cde"
@@ -9206,36 +8332,6 @@ webpack@5.76.1:
     schema-utils "^3.1.0"
     tapable "^2.1.1"
     terser-webpack-plugin "^5.1.3"
-    watchpack "^2.4.0"
-    webpack-sources "^3.2.3"
-
-webpack@5.80.0:
-  version "5.80.0"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.80.0.tgz#3e660b4ab572be38c5e954bdaae7e2bf76010fdc"
-  integrity sha512-OIMiq37XK1rWO8mH9ssfFKZsXg4n6klTEDL7S8/HqbAOBBaiy8ABvXvz0dDCXeEF9gqwxSvVk611zFPjS8hJxA==
-  dependencies:
-    "@types/eslint-scope" "^3.7.3"
-    "@types/estree" "^1.0.0"
-    "@webassemblyjs/ast" "^1.11.5"
-    "@webassemblyjs/wasm-edit" "^1.11.5"
-    "@webassemblyjs/wasm-parser" "^1.11.5"
-    acorn "^8.7.1"
-    acorn-import-assertions "^1.7.6"
-    browserslist "^4.14.5"
-    chrome-trace-event "^1.0.2"
-    enhanced-resolve "^5.13.0"
-    es-module-lexer "^1.2.1"
-    eslint-scope "5.1.1"
-    events "^3.2.0"
-    glob-to-regexp "^0.4.1"
-    graceful-fs "^4.2.9"
-    json-parse-even-better-errors "^2.3.1"
-    loader-runner "^4.2.0"
-    mime-types "^2.1.27"
-    neo-async "^2.6.2"
-    schema-utils "^3.1.2"
-    tapable "^2.1.1"
-    terser-webpack-plugin "^5.3.7"
     watchpack "^2.4.0"
     webpack-sources "^3.2.3"
 
@@ -9536,9 +8632,9 @@ zone.js@~0.10.3:
   resolved "https://registry.yarnpkg.com/zone.js/-/zone.js-0.10.3.tgz#3e5e4da03c607c9dcd92e37dd35687a14a140c16"
   integrity sha512-LXVLVEq0NNOqK/fLJo3d0kfzd4sxwn2/h67/02pjCjfKDxgx1i9QqpvtHD8CrBnSSwMw5+dy11O7FRX5mkO7Cg==
 
-zone.js@~0.13.0:
-  version "0.13.0"
-  resolved "https://registry.yarnpkg.com/zone.js/-/zone.js-0.13.0.tgz#4c735cb8ef49312b58c0ad13451996dc2b202a6d"
-  integrity sha512-7m3hNNyswsdoDobCkYNAy5WiUulkMd3+fWaGT9ij6iq3Zr/IwJo4RMCYPSDjT+r7tnPErmY9sZpKhWQ8S5k6XQ==
+zone.js@~0.13.1:
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/zone.js/-/zone.js-0.13.1.tgz#ea06f6a80ba8ac0c68e412365ae72e2cd0787982"
+  integrity sha512-+bIeDAFEBYuXRuU3qGQvzdPap+N1zjM4KkBAiiQuVVCrHrhjDuY6VkUhNa5+U27+9w0q3fbKiMCbpJ0XzMmSWA==
   dependencies:
     tslib "^2.3.0"


### PR DESCRIPTION
# Issues Addressed Migrating From Bootstrap 3 to Bootstrap 5
- [x] Once there are 6 grids total on the home page the images disappear ✅ 2023-07-19
- [x] Navbar *Hello, {{firstname}}* dropdown disappeared for some reason ✅ 2023-07-18
- [x] Navbar has vertical text wrapping issues ✅ 2023-07-18
	- [x] Adjusted the words in the Navbar ✅ 2023-07-18
- [x] Using bootstrap icons instead of glyphicon (removed in bootstrap 4) ✅ 2023-07-18
- [x] Need to fix the "Need to know" at the top of the website. ✅ 2023-07-19
	- [x] Fix the format of the popup text from the "Here's how you know". Right now too big ✅ 2023-07-20
- [x] Fixing the format of the Table Search in the Solicitations Table ✅ 2023-07-18
	- [x] Moved "Search all Table Content" into input placeholder text ✅ 2023-07-18
- [x] Fix the Format for the Donut Charts in the Analytics Page ✅ 2023-07-19
- [x] Look into the MASQUERADE & metric downloads formatting in the admin page ✅ 2023-07-21
- [x] Fixed the Download CSV link allow to hover and change in the Analytics page ✅ 2023-07-18
- [x] Mitigate tabnabbing security vulnerability with ```rel="noopener noreferrer"``` ✅ 2023-07-19
- [x] Need to fix the FAQ ✅ 2023-07-21
	- [x] Convert to panel to accordion ✅ 2023-07-19
	- [x] Get the side links to be stick and formatted correctly ✅ 2023-07-21
- [x] The individual tabs for the solicitation summary tabs need a blue background ✅ 2023-07-25
- [x] Email POC Page style fix ✅ 2023-07-25
- [x] Fixed the Download CSV button in the analytics page ✅ 2023-07-25
- [x] Made the sidbar-nav in the admin tab to be sticky ✅ 2023-07-25
- [x] Mitigate tabnabbing with art-button and add hover look
## Packages Removed:
- @angular-builders/custom-webpack
