### PR TITLE
Update Analytic Page with Total Solicitations and Formatted Labels

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -159,11 +159,10 @@
       }
     }
   },
-  "defaultProject": "srt",
   "schematics": {
     "@schematics/angular:component": {
       "prefix": "app",
-      "styleext": "css"
+      "style": "css"
     },
     "@schematics/angular:directive": {
       "prefix": "app"

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "angular2-font-awesome": "^1.3.0",
     "angular2-tooltip": "^3.1.0",
     "chart.js": "^4.3.0",
+    "chart.js-plugin-labels-dv": "^5.0.1-beta",
     "chart.piecelabel.js": "^0.15.0",
     "chartjs-adapter-date-fns": "^3.0.0",
     "classlist.js": "^1.1.20150312",

--- a/src/app/analytics/analytics.component.html
+++ b/src/app/analytics/analytics.component.html
@@ -114,8 +114,11 @@
                 <app-user-login></app-user-login>
             </div> -->
             <!-- <div class="exclude"> -->
-                <app-undetermined-solicitations [UndeterminedSolicitationChart]="UndeterminedSolicitationChart"></app-undetermined-solicitations>
-            <!-- </div> -->
+            <div class="row">
+                <app-solicitation-result class="col-lg-6" [SolicitationResultChart]="PredictResultChart"></app-solicitation-result>
+                <app-undetermined-solicitations class="col-lg-6" [UndeterminedSolicitationChart]="UndeterminedSolicitationChart"></app-undetermined-solicitations>
+            </div>
+                <!-- </div> -->
             <!-- <div class="machine-readable">
                 <app-machine-readable [MachineReadableChart]="MachineReadableChart" ></app-machine-readable>
             </div> -->

--- a/src/app/analytics/analytics.module.ts
+++ b/src/app/analytics/analytics.module.ts
@@ -21,6 +21,7 @@ import { TopAgenciesPercentageComponent } from './top-agencies-percentage/top-ag
 import { UndeterminedSolicitationsComponent } from './undetermined-solicitations/undetermined-solicitations.component';
 import { LineChartsComponent } from './line-charts/line-charts.component';
 import { DonutChartComponent } from './donut-chart/donut-chart.component';
+import { SolicitationResultComponent } from './solicitation-result/solicitation-result.component';
 
 // Service
 import { AnalyticsService } from './services/analytics.service';
@@ -47,6 +48,7 @@ import { AnalyticsService } from './services/analytics.service';
     UndeterminedSolicitationsComponent,
     LineChartsComponent,
     DonutChartComponent,
+    SolicitationResultComponent,
   ],
   providers: [
     AnalyticsService

--- a/src/app/analytics/solicitation-result/solicitation-result.component.css
+++ b/src/app/analytics/solicitation-result/solicitation-result.component.css
@@ -1,0 +1,9 @@
+.sol-result-container {
+    padding: 0px 15px;
+}
+
+.sol-result-title {
+    font-size: 20px;
+    margin-bottom: 20px;
+    font-weight: 600;
+}

--- a/src/app/analytics/solicitation-result/solicitation-result.component.html
+++ b/src/app/analytics/solicitation-result/solicitation-result.component.html
@@ -1,0 +1,17 @@
+<div class="sol-result-container">
+    <div class="sol-result-title">
+        <h2 class="srt-blue chart">
+            Total Solicitations Review Results
+        </h2>
+    </div>
+
+    <div>
+        <canvas baseChart
+                [data]="pieChartData"
+                [options]="options"
+                [type]="pieChartType"
+                [plugins]="pieChartPlugins">
+        </canvas>
+    </div>
+
+</div>

--- a/src/app/analytics/solicitation-result/solicitation-result.component.spec.ts
+++ b/src/app/analytics/solicitation-result/solicitation-result.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SolicitationResultComponent } from './solicitation-result.component';
+
+describe('SolicitationResultComponent', () => {
+  let component: SolicitationResultComponent;
+  let fixture: ComponentFixture<SolicitationResultComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ SolicitationResultComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(SolicitationResultComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/analytics/solicitation-result/solicitation-result.component.ts
+++ b/src/app/analytics/solicitation-result/solicitation-result.component.ts
@@ -1,0 +1,101 @@
+import { Component, OnInit, Input, ViewChild} from '@angular/core';
+import { BaseChartDirective } from 'ng2-charts';
+import { getChartLabelPlugin, PLUGIN_ID } from 'chart.js-plugin-labels-dv';
+
+@Component({
+  selector: 'app-solicitation-result',
+  templateUrl: './solicitation-result.component.html',
+  styleUrls: ['./solicitation-result.component.css']
+})
+export class SolicitationResultComponent {
+
+  @Input() SolicitationResultChart;
+  @ViewChild(BaseChartDirective, {static: false}) private baseChart;
+
+  public displayCompliance = '';
+  public displayUncompliance = '';
+  public displayNotApplicable = '';
+
+  public numCompliant = 0;
+  public numNonCompliant = 0;
+  public numNotApplicable = 0;
+
+  public hasValue = false;
+  public pieChartLabels: string[] = ['Compliant', 'Not Compliant', 'Not Applicable'];
+  public pieChartData: any;
+
+  public pieChartType = 'pie';
+  public pieChartPlugins = [getChartLabelPlugin()];
+
+  public options: any = {
+    cutout: 0,
+    layout: {
+      padding: {
+        top: 20,
+      }
+    },
+    plugins: {
+      labels: {
+        render: 'percentage',
+        precision: 1,
+        fontSize: 16,
+        fontColor: '#fffff',
+        position: 'outside',
+        outsidePadding: 4,
+        textMargin: 6,
+      },
+      legend: {
+          display: true,
+          position: 'bottom',
+          onClick: function() {
+          }
+      }
+    },
+    maintainAspectRatio: false,
+    responsive: true,
+  };
+
+  /**
+   * constructor
+   */
+  constructor( ) { }
+
+  /**
+   * lifecycle
+   */
+  ngOnInit() {}
+
+  /**
+   * lifecycle
+   */
+  // tslint:disable-next-line:use-lifecycle-interface
+  ngOnChanges() {
+    if (this.SolicitationResultChart && !this.hasValue) {
+      this.numCompliant = this.SolicitationResultChart.compliance;
+      this.numNonCompliant = this.SolicitationResultChart.uncompliance;
+      this.numNotApplicable = this.SolicitationResultChart.notApplicable;
+      
+      this.pieChartData = {
+        labels: this.pieChartLabels,
+
+        datasets: [{
+          data: [this.numCompliant, this.numNonCompliant, this.numNotApplicable], 
+          backgroundColor: ['#2C81C0', '#ff0000', '#e8e8e8',], 
+          borderColor: ['#2C81C0', '#ff0000', '#e8e8e8',]
+        }]
+      };
+
+      this.hasValue = true;
+      this.forceChartRefresh();
+    }
+  }
+
+  // refresh the charts
+  forceChartRefresh() {
+    setTimeout(() => {
+        this.baseChart.update();
+    }, 10);
+  }
+
+
+}

--- a/src/app/analytics/undetermined-solicitations/undetermined-solicitations.component.css
+++ b/src/app/analytics/undetermined-solicitations/undetermined-solicitations.component.css
@@ -11,13 +11,11 @@
     }
     .undeter-solic-div{
         position: relative;
-        max-width: 350px;
     }
 
     .undeter-solic-canvas{
         display: block;
         margin: 0px auto;
-        height: 280px;
         transform: translateZ(0);
         /* font-weight.*300 */
     }

--- a/src/app/analytics/undetermined-solicitations/undetermined-solicitations.component.html
+++ b/src/app/analytics/undetermined-solicitations/undetermined-solicitations.component.html
@@ -14,27 +14,9 @@
           <canvas baseChart
                   [data]="pieChartData"
                   [options]="options"
-                  [type]="pieChartType">
+                  [type]="pieChartType"
+                  [plugins]="pieChartPlugins">
           </canvas>
-      </div>
-      <div *ngIf="displayPresolicitation != '0%'" class="undeter-solic-dispaly1" aria-hidden="true">
-            {{displayPresolicitation}}
-      </div>
-      <div *ngIf="displayNonMachineReadable != '0%'" class="undeter-solic-dispaly2" aria-hidden="true">
-            {{displayNonMachineReadable}}
-      </div>
-      <div *ngIf="displayNoDocument != '0%'" class="undeter-solic-dispaly3" aria-hidden="true">
-            {{displayNoDocument}}
-      </div>
-      <div  *ngIf="displayOtherUndetermined != '0%'" class="undeter-solic-dispaly4" aria-hidden="true">
-            {{displayOtherUndetermined}}
-      </div>
-      <div class="visually-hidden">
-        <p>Chart data:</p>
-        <p>Pre-solicitation {{displayPresolicitation}}</p>
-        <p>Non Machine Readable {{displayNonMachineReadable}}</p>
-        <p>No Documents {{displayNoDocument}}</p>
-        <p>Other Undetermined {{displayOtherUndetermined}}</p>
       </div>
     </div>
 

--- a/src/app/analytics/undetermined-solicitations/undetermined-solicitations.component.ts
+++ b/src/app/analytics/undetermined-solicitations/undetermined-solicitations.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit, Input, ViewChild} from '@angular/core';
 
 import { BaseChartDirective } from 'ng2-charts';
 import { Color } from 'chart.js';
+import { getChartLabelPlugin, PLUGIN_ID } from 'chart.js-plugin-labels-dv';
 
 
 @Component({
@@ -21,9 +22,25 @@ export class UndeterminedSolicitationsComponent implements OnInit {
   public pieChartData: any;
 
   public pieChartType = 'pie';
+  public pieChartPlugins = [getChartLabelPlugin()];
+
   public options: any = {
     cutout: 0,
+    layout: {
+      padding: {
+        top: 20,
+      }
+    },
     plugins: {
+      labels: {
+        render: 'percentage',
+        precision: 1,
+        fontSize: 16,
+        fontColor: '#fffff',
+        position: 'outside',
+        outsidePadding: 4,
+        textMargin: 6,
+      },
       legend: {
           display: true,
           position: 'bottom',
@@ -67,7 +84,6 @@ export class UndeterminedSolicitationsComponent implements OnInit {
    */
   // tslint:disable-next-line:use-lifecycle-interface
   ngOnChanges() {
-
     if (this.UndeterminedSolicitationChart && !this.hasValue) {
       const presolicitation = this.UndeterminedSolicitationChart.presolicitation;
       const undetermined = this.UndeterminedSolicitationChart.latestOtherUndetermined;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2911,6 +2911,11 @@ chardet@^0.7.0:
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
 
+chart.js-plugin-labels-dv@^5.0.1-beta:
+  version "5.0.1-beta"
+  resolved "https://registry.yarnpkg.com/chart.js-plugin-labels-dv/-/chart.js-plugin-labels-dv-5.0.1-beta.tgz#d17a50d32e70d7575fb725062564480a33f67c84"
+  integrity sha512-Z0IZ5MpysGIpQ0awiPqxxvont0oQJcZZJnn23ujpbtsETQ0EmQGOGOU7zzTPuuLBLhVPYP+o8OLV+BKmjcoDJA==
+
 chart.js@^2.1.5:
   version "2.9.4"
   resolved "https://registry.yarnpkg.com/chart.js/-/chart.js-2.9.4.tgz#0827f9563faffb2dc5c06562f8eb10337d5b9684"


### PR DESCRIPTION
# Changes
- [Styleext changed to style](https://github.com/GSA/srt-ui/commit/7ee8cbdd600e564b68d2343f62c08c30e8455088)
- [Adding chartjs label plugin](https://github.com/GSA/srt-ui/commit/cdcc8520f7c053f39329eac02941a3e64a5b0780)
- [Utilize label plugin to properly display percentage](https://github.com/GSA/srt-ui/commit/72664a6d5e5bfc58d5d2cd5b827ff61a502831fe)
- [Add total solicitation result chart](https://github.com/GSA/srt-ui/commit/24e7395d68e29f5394849c9f2bb08d3b1d538acc) 

# Tickets Addressed
- [SRT-UI: Get The Percentage of The Bottom Chart to format properly](https://trello.com/c/ey6mmYOt)
- [SRT-UI: Include N/A to prelim findings chart.](https://trello.com/c/SWP35wjG)