### PR TITLE
Implementing Cannot Evaluate Category In Table & Analytics

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "srt",
-  "version": "0.0.0",
+  "version": "1.2.0dev1",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/analytics/analytics.component.spec.ts
+++ b/src/app/analytics/analytics.component.spec.ts
@@ -22,6 +22,7 @@ import { TopAgenciesPercentageComponent } from './top-agencies-percentage/top-ag
 import { UndeterminedSolicitationsComponent } from './undetermined-solicitations/undetermined-solicitations.component';
 import { LineChartsComponent } from './line-charts/line-charts.component';
 import { DonutChartComponent } from './donut-chart/donut-chart.component';
+import { SolicitationResultComponent } from './solicitation-result/solicitation-result.component';
 
 
 import {of} from 'rxjs';
@@ -37,7 +38,7 @@ describe('AnalyticsComponent', () => {
                       UserLoginComponent, MachineReadableComponent,
                       PredictionResultComponent, TopAgenciesPercentageComponent,
                       UndeterminedSolicitationsComponent, LineChartsComponent,
-                      DonutChartComponent, ],
+                      DonutChartComponent, SolicitationResultComponent],
       providers: [Globals, AnalyticsService, BaseChartDirective],
       imports: [NgChartsModule, TooltipModule, FormsModule, RouterTestingModule.withRoutes([]), HttpClientTestingModule]
     })

--- a/src/app/analytics/solicitation-result/solicitation-result.component.spec.ts
+++ b/src/app/analytics/solicitation-result/solicitation-result.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SolicitationResultComponent } from './solicitation-result.component';
+import { NgChartsModule, BaseChartDirective } from 'ng2-charts';
 
 describe('SolicitationResultComponent', () => {
   let component: SolicitationResultComponent;
@@ -8,7 +9,9 @@ describe('SolicitationResultComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ SolicitationResultComponent ]
+      declarations: [ SolicitationResultComponent ],
+      providers: [BaseChartDirective],
+      imports: [NgChartsModule]
     })
     .compileComponents();
 
@@ -20,4 +23,41 @@ describe('SolicitationResultComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('should set pie chart data when SolicitationResultChart is defined and hasValue is false', () => {
+    const chart = {
+      compliance: 10,
+      uncompliance: 5,
+      notApplicable: 3,
+      cannotEvaluate: 2,
+    };
+    component.SolicitationResultChart = chart;
+    component.hasValue = false;
+    component.ngOnChanges();
+    expect(component.numCompliant).toEqual(chart.compliance);
+    expect(component.numNonCompliant).toEqual(chart.uncompliance);
+    expect(component.numNotApplicable).toEqual(chart.notApplicable);
+    expect(component.numCannotEvaluate).toEqual(chart.cannotEvaluate);
+    expect(component.pieChartData.labels).toEqual(component.pieChartLabels);
+    expect(component.pieChartData.datasets[0].data).toEqual([
+      chart.compliance,
+      chart.uncompliance,
+      chart.notApplicable,
+      chart.cannotEvaluate,
+    ]);
+    expect(component.pieChartData.datasets[0].backgroundColor).toEqual([
+      '#2C81C0',
+      '#ff0000',
+      '#e8e8e8',
+      '#FFB300',
+    ]);
+    expect(component.pieChartData.datasets[0].borderColor).toEqual([
+      '#2C81C0',
+      '#ff0000',
+      '#e8e8e8',
+      '#FFB300',
+    ]);
+    expect(component.hasValue).toBeTrue();
+  });
+
 });

--- a/src/app/analytics/solicitation-result/solicitation-result.component.ts
+++ b/src/app/analytics/solicitation-result/solicitation-result.component.ts
@@ -19,9 +19,10 @@ export class SolicitationResultComponent {
   public numCompliant = 0;
   public numNonCompliant = 0;
   public numNotApplicable = 0;
+  public numCannotEvaluate = 0;
 
   public hasValue = false;
-  public pieChartLabels: string[] = ['Compliant', 'Not Compliant', 'Not Applicable'];
+  public pieChartLabels: string[] = ['Compliant', 'Not Compliant', 'Not Applicable', 'Cannot Evaluate'];
   public pieChartData: any;
 
   public pieChartType = 'pie';
@@ -74,14 +75,16 @@ export class SolicitationResultComponent {
       this.numCompliant = this.SolicitationResultChart.compliance;
       this.numNonCompliant = this.SolicitationResultChart.uncompliance;
       this.numNotApplicable = this.SolicitationResultChart.notApplicable;
+      this.numCannotEvaluate = this.SolicitationResultChart.cannotEvaluate;
+
       
       this.pieChartData = {
         labels: this.pieChartLabels,
 
         datasets: [{
-          data: [this.numCompliant, this.numNonCompliant, this.numNotApplicable], 
-          backgroundColor: ['#2C81C0', '#ff0000', '#e8e8e8',], 
-          borderColor: ['#2C81C0', '#ff0000', '#e8e8e8',]
+          data: [this.numCompliant, this.numNonCompliant, this.numNotApplicable, this.numCannotEvaluate], 
+          backgroundColor: ['#2C81C0', '#ff0000', '#e8e8e8', '#FFB300'], 
+          borderColor: ['#2C81C0', '#ff0000', '#e8e8e8','#FFB300']
         }]
       };
 

--- a/src/app/solicitation/solicitation-report/solicitation-report.component.css
+++ b/src/app/solicitation/solicitation-report/solicitation-report.component.css
@@ -89,6 +89,15 @@ p-dropdown .p-dropdown {
 }
 
 
+.result-yellow span,
+.result-yellow i
+{
+  font-size: 16px;
+  font-weight: bold;
+  color: #635401;
+}
+
+
 /*Animation */
 ul.cb-slide-show {
     padding-left: 0px;

--- a/src/app/solicitation/solicitation-report/solicitation-report.component.html
+++ b/src/app/solicitation/solicitation-report/solicitation-report.component.html
@@ -109,6 +109,8 @@
               (click)="selectSol(sol)" style="border: none; text-align: left; padding: 0;">
               <i class="fa fa-exclamation-triangle" style="padding-right: 5px;"
                 *ngIf="sol.predictions.value == 'red' && sol.reviewRec != 'Not Applicable'"></i>
+                <i class="bi bi-question-diamond-fill" style="padding-right: 5px;"
+                *ngIf="sol.predictions.value == 'yellow' && sol.reviewRec != 'Not Applicable'"></i>
               <span style="text-decoration: underline;">{{sol.reviewRec}}</span>
             </button>
           </td>

--- a/src/app/solicitation/summary/results-detail/results-detail.component.html
+++ b/src/app/solicitation/summary/results-detail/results-detail.component.html
@@ -26,7 +26,7 @@
             <div *ngIf="solicitation.reviewRec !== 'Compliant'"> <!-- Button only displays for non-compliant solicitations -->
               <div class="row pt-2">
                 <div class="col-md-8">
-                  <a id="art" href="https://section508.gov/art" target="_blank"  rel="noopener noreferrer" class="btn srt-button">
+                  <a *ngIf="solicitation.reviewRec == 'Non-compliant (Action Required)'" id="art" href="https://section508.gov/art" target="_blank"  rel="noopener noreferrer" class="btn srt-button">
                     Take Action: Get 508 Requirements
                   </a>
                 </div>


### PR DESCRIPTION
# Changes
- Cannot Evaluate is displayed in the solicitation table with a unique formatting to get user's attention
- Add Cannot Evaluate to Solicitation Results for last 30 days on the Analytics Page
- Unit testing the Solicitation Result Component.