### PR TITLE
Populate Login Admin Graph with 0's for dates with no data. 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "srt",
-  "version": "1.2.0dev1",
+  "version": "1.3.0dev1",
   "license": "MIT",
   "scripts": {
     "ng": "ng",


### PR DESCRIPTION
The login graph on the admin page does not format to the proper amount of days if the login information gained from API call doesn't have values that go up to that day.

For instance, if you select 30 days on Sept. 30th but the farthest back your data goes is Sept. 15th the graph will file in to Sept 15th instead of going all 30 days back. 

This change will now result in that graph going back 30 days and will just have a 0 value corresponding to that date. 