### PR TITLE
Tooltip Formatting Fix in Analytics

### DIFF
--- a/src/app/analytics/solicitation-result/solicitation-result.component.spec.ts
+++ b/src/app/analytics/solicitation-result/solicitation-result.component.spec.ts
@@ -60,4 +60,21 @@ describe('SolicitationResultComponent', () => {
     expect(component.hasValue).toBeTrue();
   });
 
+  it('should set data to zero if undefined', () => {
+    const chart = {
+      compliance: undefined,
+      uncompliance: undefined,
+      notApplicable: undefined,
+      cannotEvaluate: undefined,
+    };
+    component.SolicitationResultChart = chart;
+    component.hasValue = false;
+    component.ngOnChanges();
+    expect(component.numCompliant).toEqual(0);
+    expect(component.numNonCompliant).toEqual(0);
+    expect(component.numNotApplicable).toEqual(0);
+    expect(component.numCannotEvaluate).toEqual(0);
+    
+  });
+
 });

--- a/src/app/analytics/solicitation-result/solicitation-result.component.ts
+++ b/src/app/analytics/solicitation-result/solicitation-result.component.ts
@@ -90,8 +90,6 @@ export class SolicitationResultComponent {
         }]
       };
 
-      console.log('Sol-result piechart data', this.pieChartData);
-
       this.hasValue = true;
       this.forceChartRefresh();
     }

--- a/src/app/analytics/solicitation-result/solicitation-result.component.ts
+++ b/src/app/analytics/solicitation-result/solicitation-result.component.ts
@@ -72,10 +72,12 @@ export class SolicitationResultComponent {
   // tslint:disable-next-line:use-lifecycle-interface
   ngOnChanges() {
     if (this.SolicitationResultChart && !this.hasValue) {
-      this.numCompliant = this.SolicitationResultChart.compliance;
-      this.numNonCompliant = this.SolicitationResultChart.uncompliance;
-      this.numNotApplicable = this.SolicitationResultChart.notApplicable;
-      this.numCannotEvaluate = this.SolicitationResultChart.cannotEvaluate;
+      // If the chart data is available, then display the chart
+      // If undefined, then set value to 0 (avoiding NaN)
+      this.numCompliant = this.SolicitationResultChart.compliance || 0;
+      this.numNonCompliant = this.SolicitationResultChart.uncompliance || 0;
+      this.numNotApplicable = this.SolicitationResultChart.notApplicable || 0;
+      this.numCannotEvaluate = this.SolicitationResultChart.cannotEvaluate || 0;
 
       
       this.pieChartData = {
@@ -87,6 +89,8 @@ export class SolicitationResultComponent {
           borderColor: ['#2C81C0', '#ff0000', '#e8e8e8','#FFB300']
         }]
       };
+
+      console.log('Sol-result piechart data', this.pieChartData);
 
       this.hasValue = true;
       this.forceChartRefresh();

--- a/src/app/analytics/undetermined-solicitations/undetermined-solicitations.component.html
+++ b/src/app/analytics/undetermined-solicitations/undetermined-solicitations.component.html
@@ -1,12 +1,13 @@
 <div class="undeter-solic-padding">
 
     <div class="srt-blue undeter-solic-title">
-      <h2 class="srt-blue chart">Last 30 Days Excluded Solicitations from SRT Prediction Results (By Category)</h2>
-        <sup class="undeter-solic-supfont"
+      <h2 class="srt-blue chart">Last 30 Days Excluded Solicitations from SRT Prediction Results (By Category)
+        <sup
             pTooltip="Other Undetermined' solicitations are solicitations with attachments that are currently failed to be accessed by the system due to various reasons (e.g., security redirect)."
             tooltipPosition="bottom">
             <i tabindex="0" class="fa fa-info-circle info" aria-hidden="true" ></i>
         </sup>
+      </h2>
     </div>
 
     <div class="undeter-solic-div">


### PR DESCRIPTION
# Changes
- Placed the superscript tag in the \<h2> tag to eliminate the weird formatting at the bottom of the analytics page.
- Implemented an additional or (||) statement to reduce the chances of NaN showing up on the Solicitation Results pie chart labels which occurs if you pass in an undefined or null value. Added a unit test for this.

