### PR TITLE
Bugfix/admin guard

### DIFF
--- a/src/app/admin-guard.service.ts
+++ b/src/app/admin-guard.service.ts
@@ -31,6 +31,10 @@ export class AdminGuard implements CanActivate {
    * @param state
    */
   canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot) {
+    if (!(this.authGuard.canActivate(route, state) && this.authGuard.isGSAAdmin)) {
+      this.router.navigate(['/auth']).catch(r => console.log(r));
+    }
+    
     return this.authGuard.canActivate(route, state) && this.authGuard.isGSAAdmin;
   }
 }

--- a/src/app/auth-guard.service.ts
+++ b/src/app/auth-guard.service.ts
@@ -57,6 +57,7 @@ export class AuthGuard implements CanActivate {
           }
         });
     }
+    return false
   }
 
   /**


### PR DESCRIPTION
User: Molly R. Balsley

Found a bug where they were able to access the analytics page when that should not be allowed. Only for admin users.

Adjusted how the adminGuard was determined. Since the AuthGuard was returning a undefined value which caused the boolean check to not work