### PR TITLE
Main components now focus with orange outline

### DIFF
--- a/src/app/home/home/home.component.css
+++ b/src/app/home/home/home.component.css
@@ -164,6 +164,7 @@ body{font-family:'Open Sans Condensed',sans-serif;font-size:18px}
 .srt-margin-bot{
     margin-bottom: 30px
 }
+                        
 .srt-block-padding{
     text-align: center;
     padding: 0px 25px

--- a/src/app/home/home/home.component.html
+++ b/src/app/home/home/home.component.html
@@ -26,7 +26,7 @@
 
         <!-- Review/Manage Workload -->
         <div class="col-md-4 col-sm-6 srt-margin-bot">
-          <a [routerLink]="['/solicitation/report']" aria-labelledby="h3rmw" class="orange">
+          <a [routerLink]="['/solicitation/report']" aria-labelledby="h3rmw" class="box-link">
             <div class="srt-1-1">
               <div>
                 <div class="srt-main-box">
@@ -57,7 +57,7 @@
 
         <!-- View Analytic -->
         <div class="col-md-4 col-sm-6 srt-margin-bot">
-          <a [routerLink]="['/analytics']" aria-labelledby="h3va"  *ngIf="isGSAAdmin">
+          <a [routerLink]="['/analytics']" aria-labelledby="h3va" class="box-link"  *ngIf="isGSAAdmin">
             <div class="srt-1-1">
               <div>
                 <div class="srt-main-box">
@@ -88,7 +88,7 @@
 
         <!-- Manage SRT Access Requests -->
         <div class="col-md-4 col-sm-6 srt-margin-bot">
-          <a [routerLink]="['/admin']" aria-labelledby="h3-admin-label" *ngIf="isGSAAdmin">
+          <a [routerLink]="['/admin']" aria-labelledby="h3-admin-label" class="box-link" *ngIf="isGSAAdmin">
             <div class="srt-1-1">
               <div>
                 <div class="srt-main-box">
@@ -152,7 +152,7 @@
 
         <!-- Contact Us -->
         <div class="col-md-4 col-sm-6 srt-margin-bot">
-          <a [routerLink]="['/help/contactus']" aria-labelledby="h3cus">
+          <a [routerLink]="['/help/contactus']" class="box-link" aria-labelledby="h3cus">
             <div class="srt-1-1">
               <div>
                 <div class="srt-main-box">
@@ -184,7 +184,7 @@
 
         <!-- FAQ -->
         <div class="col-md-4 col-sm-6 srt-margin-bot">
-          <a [routerLink]="['/help/faq']" aria-labelledby="h3faq">
+          <a [routerLink]="['/help/faq']" class="box-link" aria-labelledby="h3faq">
             <div class="srt-1-1">
               <div>
                 <div class="srt-main-box">

--- a/src/styles.css
+++ b/src/styles.css
@@ -258,7 +258,7 @@ div.srt-button {
 a:focus,
 button:focus,
 input:focus {
-  outline: solid 2px orange !important;
+  outline: orange auto 2px !important;
 }
 html,
 body {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3301,10 +3301,10 @@ core-js-compat@^3.25.1:
   dependencies:
     browserslist "^4.21.5"
 
-core-js@^3.30.2:
-  version "3.30.2"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.30.2.tgz#6528abfda65e5ad728143ea23f7a14f0dcf503fc"
-  integrity sha512-uBJiDmwqsbJCWHAwjrx3cvjbMXP7xD72Dmsn5LOJpiRmE3WbBbN5rCqQ2Qh6Ek6/eOrjlWngEynBWo4VxerQhg==
+core-js@^3.32.1:
+  version "3.37.0"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.37.0.tgz#d8dde58e91d156b2547c19d8a4efd5c7f6c426bb"
+  integrity sha512-fu5vHevQ8ZG4og+LXug8ulUtVxjOcEYvifJr7L5Bfq9GOztVqsKd9/59hUk2ZSbCrS3BqUr3EpaYGIYzq7g3Ug==
 
 core-util-is@1.0.2:
   version "1.0.2"
@@ -8235,7 +8235,7 @@ tslib@^1.10.0, tslib@^1.13.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.0, tslib@^2.1.0, tslib@^2.3.0, tslib@^2.5.0, tslib@^2.5.3:
+tslib@^2.0.0, tslib@^2.1.0, tslib@^2.3.0, tslib@^2.5.0:
   version "2.5.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.3.tgz#24944ba2d990940e6e982c4bea147aba80209913"
   integrity sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==
@@ -8244,6 +8244,11 @@ tslib@^2.0.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.1.tgz#fd8c9a0ff42590b25703c0acb3de3d3f4ede0410"
   integrity sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==
+
+tslib@^2.6.2:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
+  integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
 
 tslint@~6.1.3:
   version "6.1.3"


### PR DESCRIPTION
Needed to adjust the outline styling to be in the proper order to display correctly on the page. Picture attached to showcase change.


![srt_focus_home](https://github.com/GSA/srt-ui/assets/48027257/92a7f360-27e6-4f2e-83bd-be50ed6b62eb)
