### PR TITLE
177: Is approved option for SRT login

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -48,6 +48,6 @@
         </div>
     </div>
 
-    <app-header [isLogin]="isLogin" [isGSAAdmin]="isGSAAdmin" [firstName]="firstName"></app-header>
+    <app-header [isApproved]="isApproved" [isLogin]="isLogin" [isGSAAdmin]="isGSAAdmin" [firstName]="firstName"></app-header>
     <router-outlet></router-outlet>
 </body>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -43,31 +43,37 @@ export class AppComponent implements OnInit {
     private clientVersionService: ClientVersionService
   ) {
     globals.app = this;
-    authService.checkToken().subscribe(
-      {
-        next: (data) => {
-          this.authGuard.isApproved = data.isApproved;
-          this.authGuard.isLogin = data.isLogin;
-          this.authGuard.isGSAAdmin = data.isGSAAdmin;
-          this.isLogin = this.authGuard.isLogin;
-          this.isGSAAdmin = this.authGuard.isGSAAdmin;
-          this.isApproved = this.authGuard.isApproved;
-          this.firstName = localStorage.getItem('firstName');
-          this.lastName = localStorage.getItem('lastName');
-        
-        //console.log('data:', data);
-        //console.log('this:', this);
+
+    const token = localStorage.getItem('token');
 
 
-        // debugger
-        if (!this.authGuard.isLogin) {
-          // don't clear cache here when using MAX CAS prototype
-          // localStorage.clear();
+    if(token) {
+      authService.checkToken().subscribe(
+        {
+          next: (data) => {
+            this.authGuard.isApproved = data.isApproved;
+            this.authGuard.isLogin = data.isLogin;
+            this.authGuard.isGSAAdmin = data.isGSAAdmin;
+            this.isLogin = this.authGuard.isLogin;
+            this.isGSAAdmin = this.authGuard.isGSAAdmin;
+            this.isApproved = this.authGuard.isApproved;
+            this.firstName = localStorage.getItem('firstName');
+            this.lastName = localStorage.getItem('lastName');
+          
+          //console.log('data:', data);
+          //console.log('this:', this);
+
+
+          // debugger
+          if (!this.authGuard.isLogin) {
+            // don't clear cache here when using MAX CAS prototype
+            // localStorage.clear();
+          }
+          },
+          error: (err: any) => { console.log(err); }
         }
-        },
-        error: (err: any) => { console.log(err); }
-      }
-    );
+      );
+    }
   }
 
   ngOnInit() {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -16,6 +16,7 @@ export class AppComponent implements OnInit {
 
   /* ATTRIBUTES */
 
+  isApproved = false;
   isLogin = false;
   isGSAAdmin = false;
   firstName = '';
@@ -45,12 +46,14 @@ export class AppComponent implements OnInit {
     authService.checkToken().subscribe(
       {
         next: (data) => {
-        this.authGuard.isLogin = data.isLogin;
-        this.authGuard.isGSAAdmin = data.isGSAAdmin;
-        this.isLogin = this.authGuard.isLogin;
-        this.isGSAAdmin = this.authGuard.isGSAAdmin;
-        this.firstName = localStorage.getItem('firstName');
-        this.lastName = localStorage.getItem('lastName');
+          this.authGuard.isApproved = data.isApproved;
+          this.authGuard.isLogin = data.isLogin;
+          this.authGuard.isGSAAdmin = data.isGSAAdmin;
+          this.isLogin = this.authGuard.isLogin;
+          this.isGSAAdmin = this.authGuard.isGSAAdmin;
+          this.isApproved = this.authGuard.isApproved;
+          this.firstName = localStorage.getItem('firstName');
+          this.lastName = localStorage.getItem('lastName');
         
         //console.log('data:', data);
         //console.log('this:', this);

--- a/src/app/app.routing.ts
+++ b/src/app/app.routing.ts
@@ -13,13 +13,13 @@ import {AdminGuardFn} from './admin-guard.service';
 
 
 const routes: Routes = [
-  {path: '', redirectTo: 'home', pathMatch: 'full'},
+  {path: '', redirectTo: 'home', pathMatch: 'full', canActivate: [AuthGuardFn]},
   {path: 'auth', component: AuthComponent},
   {path: 'admin/accepted', component: AdminComponent, canActivate: [AuthGuardFn] , data: { isAccepted: true, isRejected: false }},
   {path: 'admin/masq', component: MasqComponent, canActivate: [AuthGuardFn] , data: {}},
   {path: 'admin', component: AdminComponent, canActivate: [AdminGuardFn] , data: { isAccepted: false, isRejected: false }},
   {path: 'analytics', component: AnalyticsComponent, canActivate: [AdminGuardFn]},
-  {path: 'help', component: HelpComponent},
+  {path: 'help', component: HelpComponent, canActivate: [AuthGuardFn]},
 ];
 
 @NgModule({

--- a/src/app/auth-guard.service.ts
+++ b/src/app/auth-guard.service.ts
@@ -63,8 +63,6 @@ export class AuthGuard  {
           this.isLogin = data.isLogin;
           this.isApproved = data.isApproved;
 
-          console.log('data:', data);
-
           if (data.isLogin && data.isApproved) {
             this.router.navigate([url]).catch(r => console.log(r));
             return true;

--- a/src/app/auth-guard.service.ts
+++ b/src/app/auth-guard.service.ts
@@ -18,6 +18,7 @@ export class AuthGuard  {
   /* ATTRIBUTES */
 
   public isLogin = false;
+  public isApproved = false;
   public isGSAAdmin = false;
 
   /* CONSTRUCTOR */
@@ -52,7 +53,11 @@ export class AuthGuard  {
        this.authService.checkToken().subscribe(
         (data) => {
           this.isLogin = data.isLogin;
-          if (data.isLogin) {
+          this.isApproved = data.isApproved;
+
+          console.log('data:', data);
+
+          if (data.isLogin && data.isApproved) {
             this.router.navigate([url]).catch(r => console.log(r));
             return true;
           } else {

--- a/src/app/auth-guard.service.ts
+++ b/src/app/auth-guard.service.ts
@@ -47,6 +47,14 @@ export class AuthGuard  {
    * @param url
    */
   checkLogin(url: string): boolean {
+
+    const token = localStorage.getItem('token');
+
+    if (!token) {
+      this.router.navigate(['/auth']).catch(r => console.log(r));
+      return false;
+    }
+
     if (this.isLogin) {
       return true;
     } else {

--- a/src/app/auth/auth.component.html
+++ b/src/app/auth/auth.component.html
@@ -6,8 +6,16 @@
     </h3>
   </div>
 
+  <div class="usa-alert usa-alert--error" *ngIf="isLogin && !isApproved" role="alert">
+    <div class="usa-alert__body">
+      <h4 class="usa-alert__heading">Request Access</h4>
+      <p class="usa-alert__text">
+        Your account is not approved. Please contact the SRT administrator (<a class="usa-link" href="mailto:srt@gsa.gov">srt&#64;gsa.gov</a>) to request access.
+      </p>
+    </div>
+  </div>
 
-  <div class="grid-row">
+  <div class="grid-row" *ngIf="!isLogin">
     <div class="grid-col-12">
       <div class="grid-row usa-prose">
         <div class="grid-col-8 tablet:grid-col-8 desktop:grid-col-8 desktop:grid-offset-2">

--- a/src/app/auth/auth.component.ts
+++ b/src/app/auth/auth.component.ts
@@ -1,5 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { GoogleAnalyticsService } from 'ngx-google-analytics';
+import { AuthGuard } from '../auth-guard.service';
+
 
 @Component({
   selector: 'app-auth',
@@ -11,18 +13,25 @@ export class AuthComponent implements OnInit {
    /* ATTRIBUTES */
 
   displayTab = 'singin';
+  isApproved = false;
+  isLogin = false;
+  isGSAAdmin = false;
 
   /**
    * constructor
    */
   constructor(
-    private $gaService: GoogleAnalyticsService
+    private authGuard: AuthGuard,
+    private $gaService: GoogleAnalyticsService,
   ) { }
 
   /**
    * lifecycle
    */
   ngOnInit() {
+    this.isLogin = this.authGuard.isLogin;
+    this.isGSAAdmin = this.authGuard.isGSAAdmin;
+    this.isApproved = this.authGuard.isApproved;
   }
 
   /**

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -12,17 +12,17 @@
 
                 <!-- Right Side: Navigation -->
                 <ul class="right-nav-group">
-                    <li class="nav-item">
+                    <li class="nav-item" *ngIf="isLogin && isApproved">
                         <a [routerLink]="['/home']" class="nav-link" (click)="menuClick('/home')">Home</a>
                     </li>
-                    <li class="nav-item">
+                    <li class="nav-item" *ngIf="isLogin && isApproved">
                         <a [routerLink]="['/solicitation/report']" class="nav-link" (click)="menuClick('/solicitation/report')">Daily Report</a>
                     </li>
                     <!-- Admin-only navigation items -->
-                    <li class="nav-item" *ngIf="isGSAAdmin">
+                    <li class="nav-item" *ngIf="isLogin && isGSAAdmin">
                         <a [routerLink]="['/analytics']" class="nav-link" id="nav-analytics" (click)="menuClick('/analytics')">Analytics</a>
                     </li>
-                    <li class="nav-item" *ngIf="isGSAAdmin">
+                    <li class="nav-item" *ngIf="isLogin && isGSAAdmin">
                         <a [routerLink]="['/admin']" class="nav-link" tabindex="{{ isGSAAdmin ? 0 : -1}}" (click)="menuClick('/admin')">Administration</a>
                     </li>
                     <li class="nav-item">
@@ -39,7 +39,7 @@
                     <li class="nav-item">
                         <a [routerLink]="['/help/faq']" class="nav-link" (click)="menuClick('/help/faq')">FAQs</a>
                     </li>
-                    <li class="nav-item">
+                    <li class="nav-item" *ngIf="isLogin">
                         <a href="javascript:void(0)" (click)="onLogout()" (blur)="popUpMenuLostFocus()"
                         class="nav-link" role="menuitem">Log Out</a>
                     </li>

--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -22,6 +22,7 @@ export class HeaderComponent implements OnInit {
   public currentID = '';
   @Input() isLogin;
   @Input() isGSAAdmin;
+  @Input() isApproved;
 
   /* CONSTRUCTORS */
 

--- a/src/app/home/home.routing.ts
+++ b/src/app/home/home.routing.ts
@@ -5,15 +5,15 @@ import { HomeComponent } from './home/home.component';
 import { PrivateComponent } from './private/private.component';
 
 
-import { AuthGuard } from '../auth-guard.service';
+import { AuthGuardFn } from '../auth-guard.service';
 
 const routes: Routes = [
     {
         path: '',
         component: PrivateComponent,
-        canActivate: [AuthGuard],
+        canActivate: [AuthGuardFn],
         children: [
-            {path: 'home', component: HomeComponent, canActivate : [AuthGuard]},
+            {path: 'home', component: HomeComponent, canActivate : [AuthGuardFn]},
         ]
     },
 ];


### PR DESCRIPTION
# Why The Change
- SRT Administrators need to be in the loop providing access to SRT.
- The UI will be looking at the isApproved value returned from the Server

# Changes
- Add an error message on the auth page to showcase they need to request access if they are not approved
- Don't send a checkToken request if there is no token in the localStorage, which initially caused a server error
- Adjust what tabs at the top of the page is viewable to not approved users.
- AuthGuardFn implementation looking for isApproved and isLogin.